### PR TITLE
Always run check-dist check

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -9,11 +9,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
   pull_request:
-    paths-ignore:
-      - "**.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Currently we mark it as a required check and thus prevent automatic PR merges when only markdown files are contained in the PR