### PR TITLE
🚸 use GitHub token by default

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -23,7 +23,5 @@ jobs:
           }
       - name: Setup uv
         uses: ./
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: uv sync
         working-directory: __tests__\fixtures\uv-project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install default version
         uses: ./
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: uv sync
         working-directory: __tests__/fixtures/uv-project
   test-specific-version:
@@ -46,7 +44,6 @@ jobs:
         uses: ./
         with:
           version: ${{ matrix.uv-version }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: uv sync
         working-directory: __tests__/fixtures/uv-project
   test-checksum:
@@ -69,15 +66,6 @@ jobs:
         with:
           version: "0.3.2"
           checksum: ${{ matrix.checksum }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-  test-without-github-token:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install default version
-        uses: ./
-      - run: uv sync
-        working-directory: __tests__/fixtures/uv-project
   test-uvx:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Set up your GitHub Actions workflow with a specific version of [uv](https://docs
   - [Enable Caching](#enable-caching)
     - [Local cache path](#local-cache-path)
     - [Cache dependency glob](#cache-dependency-glob)
-  - [API rate limit](#api-rate-limit)
 - [How it works](#how-it-works)
 - [FAQ](#faq)
 
@@ -133,18 +132,6 @@ changes. The glob matches files relative to the repository root.
     cache-dependency-glob: |
       '**requirements*.txt'
       '**pyproject.toml'
-```
-
-### API rate limit
-
-To avoid hitting the `API rate limit exceeded` error, supply a GitHub token via the `github-token`
-input.
-
-```yaml
-- name: Install uv and supply a GitHub token
-  uses: astral-sh/setup-uv@v2
-  with:
-    github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## How it works

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ inputs:
       "Used to increase the rate limit when retrieving versions and downloading
       uv."
     required: false
+    default: ${{ github.token }}
   enable-cache:
     description: "Enable caching of the uv cache"
     default: "false"


### PR DESCRIPTION
This PR adjusts the action so that it is no longer necessary to explicitly specify the GitHub token to circumvent the API rate limit.
To this end, it simply passes the repository's GitHub token (available via `${{ github.token }}`) as a default for the `github_token` action input.

This is similar to how this is handled in, e.g., https://github.com/peter-evans/create-pull-request; specifically [here](https://github.com/peter-evans/create-pull-request/blob/5354f85616108575685a73a0ddd2f67c26a441c3/action.yml#L4-L6).