### PR TITLE
fix example for multiple cache-dependency-glob without quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ changes. The glob matches files relative to the repository root.
   with:
     enable-cache: true
     cache-dependency-glob: |
-      '**requirements*.txt'
-      '**pyproject.toml'
+      **requirements*.txt
+      **pyproject.toml
 ```
 
 ### GitHub authentication token


### PR DESCRIPTION
I tried multiple glob like followings and got error about missing files.

```
            '${{ matrix.working-directory }}/uv.lock'
            '${{ matrix.working-directory }}/pyproject.toml'
            '${{ matrix.working-directory }}/.python-version'
```

When removed quotations, succeeded.