### PR TITLE
📝 fix dependency glob example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ changes. The glob matches files relative to the repository root.
   with:
     enable-cache: true
     cache-dependency-glob: |
-      '**requirements*.txt'
-      '**pyproject.toml'
+      **requirements*.txt
+      **pyproject.toml
 ```
 
 ### GitHub authentication token


### PR DESCRIPTION
It appears as the `'` are taken into the glob pattern, which results in no files being found.