### PR TITLE
Always use api.github.com

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -98975,7 +98975,7 @@ function resolveVersion(versionInput, githubToken) {
 }
 function getAvailableVersions(githubToken) {
     return __awaiter(this, void 0, void 0, function* () {
-        const octokit = github.getOctokit(githubToken);
+        const octokit = github.getOctokit(githubToken, { baseUrl: constants_1.GITHUB_COM_API });
         const response = yield octokit.paginate(octokit.rest.repos.listReleases, {
             owner: constants_1.OWNER,
             repo: constants_1.REPO,
@@ -98985,7 +98985,7 @@ function getAvailableVersions(githubToken) {
 }
 function getLatestVersion(githubToken) {
     return __awaiter(this, void 0, void 0, function* () {
-        const octokit = github.getOctokit(githubToken);
+        const octokit = github.getOctokit(githubToken, { baseUrl: constants_1.GITHUB_COM_API });
         const { data: latestRelease } = yield octokit.rest.repos.getLatestRelease({
             owner: constants_1.OWNER,
             repo: constants_1.REPO,
@@ -99277,10 +99277,11 @@ run();
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.TOOL_CACHE_NAME = exports.OWNER = exports.REPO = void 0;
+exports.GITHUB_COM_API = exports.TOOL_CACHE_NAME = exports.OWNER = exports.REPO = void 0;
 exports.REPO = "uv";
 exports.OWNER = "astral-sh";
 exports.TOOL_CACHE_NAME = "uv";
+exports.GITHUB_COM_API = "https://api.github.com";
 
 
 /***/ }),

--- a/dist/update-known-checksums/index.js
+++ b/dist/update-known-checksums/index.js
@@ -34685,7 +34685,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         const checksumFilePath = process.argv.slice(2)[0];
         const github_token = process.argv.slice(2)[1];
-        const octokit = github.getOctokit(github_token);
+        const octokit = github.getOctokit(github_token, { baseUrl: constants_1.GITHUB_COM_API });
         const response = yield octokit.paginate(octokit.rest.repos.listReleases, {
             owner: constants_1.OWNER,
             repo: constants_1.REPO,
@@ -34711,10 +34711,11 @@ run();
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.TOOL_CACHE_NAME = exports.OWNER = exports.REPO = void 0;
+exports.GITHUB_COM_API = exports.TOOL_CACHE_NAME = exports.OWNER = exports.REPO = void 0;
 exports.REPO = "uv";
 exports.OWNER = "astral-sh";
 exports.TOOL_CACHE_NAME = "uv";
+exports.GITHUB_COM_API = "https://api.github.com";
 
 
 /***/ }),

--- a/src/download/download-version.ts
+++ b/src/download/download-version.ts
@@ -2,7 +2,12 @@ import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
 import * as path from "node:path";
 import { promises as fs } from "node:fs";
-import { OWNER, REPO, TOOL_CACHE_NAME } from "../utils/constants";
+import {
+  GITHUB_COM_API,
+  OWNER,
+  REPO,
+  TOOL_CACHE_NAME,
+} from "../utils/constants";
 import type { Architecture, Platform } from "../utils/platforms";
 import { validateChecksum } from "./checksum/checksum";
 import * as github from "@actions/github";
@@ -91,7 +96,7 @@ export async function resolveVersion(
 }
 
 async function getAvailableVersions(githubToken: string): Promise<string[]> {
-  const octokit = github.getOctokit(githubToken);
+  const octokit = github.getOctokit(githubToken, { baseUrl: GITHUB_COM_API });
 
   const response = await octokit.paginate(octokit.rest.repos.listReleases, {
     owner: OWNER,
@@ -101,7 +106,7 @@ async function getAvailableVersions(githubToken: string): Promise<string[]> {
 }
 
 async function getLatestVersion(githubToken: string) {
-  const octokit = github.getOctokit(githubToken);
+  const octokit = github.getOctokit(githubToken, { baseUrl: GITHUB_COM_API });
 
   const { data: latestRelease } = await octokit.rest.repos.getLatestRelease({
     owner: OWNER,

--- a/src/update-known-checksums.ts
+++ b/src/update-known-checksums.ts
@@ -1,7 +1,7 @@
 import * as github from "@actions/github";
 import * as core from "@actions/core";
 
-import { OWNER, REPO } from "./utils/constants";
+import { GITHUB_COM_API, OWNER, REPO } from "./utils/constants";
 import * as semver from "semver";
 
 import { updateChecksums } from "./download/checksum/update-known-checksums";
@@ -10,7 +10,7 @@ async function run(): Promise<void> {
   const checksumFilePath = process.argv.slice(2)[0];
   const github_token = process.argv.slice(2)[1];
 
-  const octokit = github.getOctokit(github_token);
+  const octokit = github.getOctokit(github_token, { baseUrl: GITHUB_COM_API });
 
   const response = await octokit.paginate(octokit.rest.repos.listReleases, {
     owner: OWNER,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,4 @@
 export const REPO = "uv";
 export const OWNER = "astral-sh";
 export const TOOL_CACHE_NAME = "uv";
+export const GITHUB_COM_API = "https://api.github.com";


### PR DESCRIPTION
The octokit client would default to the URL of enterprise instances and then not be able to find the uv repo.

Closes: #188