### PR TITLE
docs: bump `astral-sh/setup-uv` to `v5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Set up your GitHub Actions workflow with a specific version of [uv](https://docs
 
 ```yaml
 - name: Install the latest version of uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     version: "latest"
 ```
@@ -46,7 +46,7 @@ For an example workflow, see
 
 ```yaml
 - name: Install a specific version of uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     version: "0.4.4"
 ```
@@ -58,14 +58,14 @@ to install the latest version that satisfies the range.
 
 ```yaml
 - name: Install a semver range of uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     version: ">=0.4.0"
 ```
 
 ```yaml
 - name: Pinning a minor version of uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     version: "0.4.x"
 ```
@@ -82,7 +82,7 @@ This will override any python version specifications in `pyproject.toml` and `.p
 
 ```yaml
 - name: Install the latest version of uv and set the python version to 3.13t
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     python-version: 3.13t
 - run: uv pip install --python=3.13t pip
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install the latest version of uv and set the python version
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Test with python ${{ matrix.python-version }}
@@ -115,7 +115,7 @@ are automatically verified by this action. The sha256 hashes can be found on the
 
 ```yaml
 - name: Install a specific version and validate the checksum
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     version: "0.3.1"
     checksum: "e11b01402ab645392c7ad6044db63d37e4fd1e745e015306993b07695ea5f9f8"
@@ -136,7 +136,7 @@ You can optionally define a custom cache key suffix.
 ```yaml
 - name: Enable caching and define a custom cache key suffix
   id: setup-uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
     cache-suffix: "optional-suffix"
@@ -168,7 +168,7 @@ changes. If you use relative paths, they are relative to the repository root.
 
 ```yaml
 - name: Define a cache dependency glob
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
     cache-dependency-glob: "**/pyproject.toml"
@@ -176,7 +176,7 @@ changes. If you use relative paths, they are relative to the repository root.
 
 ```yaml
 - name: Define a list of cache dependency globs
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
     cache-dependency-glob: |
@@ -186,7 +186,7 @@ changes. If you use relative paths, they are relative to the repository root.
 
 ```yaml
 - name: Define an absolute cache dependency glob
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
     cache-dependency-glob: "/tmp/my-folder/requirements*.txt"
@@ -194,7 +194,7 @@ changes. If you use relative paths, they are relative to the repository root.
 
 ```yaml
 - name: Never invalidate the cache
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
     cache-dependency-glob: ""
@@ -209,7 +209,7 @@ It defaults to `setup-uv-cache` in the `TMP` dir, `D:\a\_temp\uv-tool-dir` on Wi
 
 ```yaml
 - name: Define a custom uv cache path
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     cache-local-path: "/path/to/cache"
 ```
@@ -228,7 +228,7 @@ input.
 
 ```yaml
 - name: Don't prune the cache before saving it
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
     prune-cache: false
@@ -241,7 +241,7 @@ If you want to ignore this, set the `ignore-nothing-to-cache` input to `true`.
 
 ```yaml
 - name: Ignore nothing to cache
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
     ignore-nothing-to-cache: true
@@ -259,7 +259,7 @@ are not sufficient, you can provide a custom GitHub token with the necessary per
 
 ```yaml
 - name: Install the latest version of uv with a custom GitHub token
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
 ```
@@ -277,7 +277,7 @@ input:
 
 ```yaml
 - name: Install the latest version of uv with a custom tool dir
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     tool-dir: "/path/to/tool/dir"
 ```
@@ -296,7 +296,7 @@ If you want to change this behaviour (especially on self-hosted runners) you can
 
 ```yaml
 - name: Install the latest version of uv with a custom tool bin dir
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     tool-bin-dir: "/path/to/tool-bin/dir"
 ```
@@ -312,7 +312,7 @@ This action supports expanding the `~` character to the user's home directory fo
 
 ```yaml
 - name: Expand the tilde character
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     cache-local-path: "~/path/to/cache"
     tool-dir: "~/path/to/tool/dir"
@@ -344,7 +344,7 @@ For example:
 - name: Checkout the repository
   uses: actions/checkout@main
 - name: Install the latest version of uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
 - name: Test
@@ -356,7 +356,7 @@ To install a specific version of Python, use
 
 ```yaml
 - name: Install the latest version of uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
   with:
     enable-cache: true
 - name: Install Python 3.12
@@ -375,7 +375,7 @@ output:
   uses: actions/checkout@main
 - name: Install the default version of uv
   id: setup-uv
-  uses: astral-sh/setup-uv@v4
+  uses: astral-sh/setup-uv@v5
 - name: Print the installed version
   run: echo "Installed uv version is ${{ steps.setup-uv.outputs.uv-version }}"
 ```


### PR DESCRIPTION
Found the version in the documentation is not the latest when I copy it.