### PR TITLE
Remove uv version from cache key

### DIFF
--- a/dist/save-cache/index.js
+++ b/dist/save-cache/index.js
@@ -91465,9 +91465,9 @@ const exec = __importStar(__nccwpck_require__(5236));
 exports.STATE_CACHE_KEY = "cache-key";
 exports.STATE_CACHE_MATCHED_KEY = "cache-matched-key";
 const CACHE_VERSION = "1";
-function restoreCache(version) {
+function restoreCache() {
     return __awaiter(this, void 0, void 0, function* () {
-        const cacheKey = yield computeKeys(version);
+        const cacheKey = yield computeKeys();
         let matchedKey;
         core.info(`Trying to restore uv cache from GitHub Actions cache with key: ${cacheKey}`);
         try {
@@ -91483,7 +91483,7 @@ function restoreCache(version) {
         handleMatchResult(matchedKey, cacheKey);
     });
 }
-function computeKeys(version) {
+function computeKeys() {
     return __awaiter(this, void 0, void 0, function* () {
         let cacheDependencyPathHash = "-";
         if (inputs_1.cacheDependencyGlob !== "") {
@@ -91498,7 +91498,7 @@ function computeKeys(version) {
         }
         const suffix = inputs_1.cacheSuffix ? `-${inputs_1.cacheSuffix}` : "";
         const pythonVersion = yield getPythonVersion();
-        return `setup-uv-${CACHE_VERSION}-${(0, platforms_1.getArch)()}-${(0, platforms_1.getPlatform)()}-${version}-${pythonVersion}${cacheDependencyPathHash}${suffix}`;
+        return `setup-uv-${CACHE_VERSION}-${(0, platforms_1.getArch)()}-${(0, platforms_1.getPlatform)()}-${pythonVersion}${cacheDependencyPathHash}${suffix}`;
     });
 }
 function getPythonVersion() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96548,9 +96548,9 @@ const exec = __importStar(__nccwpck_require__(5236));
 exports.STATE_CACHE_KEY = "cache-key";
 exports.STATE_CACHE_MATCHED_KEY = "cache-matched-key";
 const CACHE_VERSION = "1";
-function restoreCache(version) {
+function restoreCache() {
     return __awaiter(this, void 0, void 0, function* () {
-        const cacheKey = yield computeKeys(version);
+        const cacheKey = yield computeKeys();
         let matchedKey;
         core.info(`Trying to restore uv cache from GitHub Actions cache with key: ${cacheKey}`);
         try {
@@ -96566,7 +96566,7 @@ function restoreCache(version) {
         handleMatchResult(matchedKey, cacheKey);
     });
 }
-function computeKeys(version) {
+function computeKeys() {
     return __awaiter(this, void 0, void 0, function* () {
         let cacheDependencyPathHash = "-";
         if (inputs_1.cacheDependencyGlob !== "") {
@@ -96581,7 +96581,7 @@ function computeKeys(version) {
         }
         const suffix = inputs_1.cacheSuffix ? `-${inputs_1.cacheSuffix}` : "";
         const pythonVersion = yield getPythonVersion();
-        return `setup-uv-${CACHE_VERSION}-${(0, platforms_1.getArch)()}-${(0, platforms_1.getPlatform)()}-${version}-${pythonVersion}${cacheDependencyPathHash}${suffix}`;
+        return `setup-uv-${CACHE_VERSION}-${(0, platforms_1.getArch)()}-${(0, platforms_1.getPlatform)()}-${pythonVersion}${cacheDependencyPathHash}${suffix}`;
     });
 }
 function getPythonVersion() {
@@ -99274,7 +99274,7 @@ function run() {
             core.setOutput("uv-version", setupResult.version);
             core.info(`Successfully installed uv version ${setupResult.version}`);
             if (inputs_1.enableCache) {
-                yield (0, restore_cache_1.restoreCache)(setupResult.version);
+                yield (0, restore_cache_1.restoreCache)();
             }
             process.exit(0);
         }

--- a/src/cache/restore-cache.ts
+++ b/src/cache/restore-cache.ts
@@ -14,8 +14,8 @@ export const STATE_CACHE_KEY = "cache-key";
 export const STATE_CACHE_MATCHED_KEY = "cache-matched-key";
 const CACHE_VERSION = "1";
 
-export async function restoreCache(version: string): Promise<void> {
-  const cacheKey = await computeKeys(version);
+export async function restoreCache(): Promise<void> {
+  const cacheKey = await computeKeys();
 
   let matchedKey: string | undefined;
   core.info(
@@ -35,7 +35,7 @@ export async function restoreCache(version: string): Promise<void> {
   handleMatchResult(matchedKey, cacheKey);
 }
 
-async function computeKeys(version: string): Promise<string> {
+async function computeKeys(): Promise<string> {
   let cacheDependencyPathHash = "-";
   if (cacheDependencyGlob !== "") {
     core.info(
@@ -53,7 +53,7 @@ async function computeKeys(version: string): Promise<string> {
   }
   const suffix = cacheSuffix ? `-${cacheSuffix}` : "";
   const pythonVersion = await getPythonVersion();
-  return `setup-uv-${CACHE_VERSION}-${getArch()}-${getPlatform()}-${version}-${pythonVersion}${cacheDependencyPathHash}${suffix}`;
+  return `setup-uv-${CACHE_VERSION}-${getArch()}-${getPlatform()}-${pythonVersion}${cacheDependencyPathHash}${suffix}`;
 }
 
 async function getPythonVersion(): Promise<string> {

--- a/src/setup-uv.ts
+++ b/src/setup-uv.ts
@@ -55,7 +55,7 @@ async function run(): Promise<void> {
     core.info(`Successfully installed uv version ${setupResult.version}`);
 
     if (enableCache) {
-      await restoreCache(setupResult.version);
+      await restoreCache();
     }
     process.exit(0);
   } catch (err) {


### PR DESCRIPTION
This approach was copied from setup-rye but uv now has the capability to determine if a cache version is compatible. By removing it we will less frequently invalidate the cache and thus save bandwidth

Closes: #203