### PR TITLE
fix: add full path to venv bin

### DIFF
--- a/src/setup-uv.ts
+++ b/src/setup-uv.ts
@@ -161,7 +161,7 @@ async function setupPython(): Promise<void> {
     if (process.platform === "win32") {
       venvBinPath = ".venv/Scripts";
     }
-    core.addPath(venvBinPath);
+    core.addPath(path.resolve(venvBinPath));
     core.exportVariable("VIRTUAL_ENV", path.resolve(".venv"));
   }
 }


### PR DESCRIPTION
Resolves the full path to the directory containing binaries installed by uv.

Fixes #239.