### PR TITLE
feat: support s390x and powerpc

### DIFF
--- a/dist/save-cache/index.js
+++ b/dist/save-cache/index.js
@@ -91860,6 +91860,8 @@ function getArch() {
         ia32: "i686",
         x64: "x86_64",
         arm64: "aarch64",
+        s390x: "s390x",
+        ppc64: "powerpc64le",
     };
     if (arch in archMapping) {
         return archMapping[arch];

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -4,7 +4,12 @@ export type Platform =
   | "unknown-linux-musleabihf"
   | "apple-darwin"
   | "pc-windows-msvc";
-export type Architecture = "i686" | "x86_64" | "aarch64";
+export type Architecture =
+  | "i686"
+  | "x86_64"
+  | "aarch64"
+  | "s390x"
+  | "powerpc64le";
 
 export function getArch(): Architecture | undefined {
   const arch = process.arch;
@@ -12,6 +17,8 @@ export function getArch(): Architecture | undefined {
     ia32: "i686",
     x64: "x86_64",
     arm64: "aarch64",
+    s390x: "s390x",
+    ppc64: "powerpc64le",
   };
 
   if (arch in archMapping) {


### PR DESCRIPTION
This patch adds support for `s390x` and `powerpc`.

According https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list , only `powerpcle` available on Linux. So we always use `uv-powerpc64le-unknown-linux-gnu`