### PR TITLE
Refactor setupPython to use uv python pin & venv setup

### DIFF
--- a/src/utils/pyproject.ts
+++ b/src/utils/pyproject.ts
@@ -43,3 +43,31 @@ function getRequiredVersion(filePath: string): string | undefined {
   };
   return tomlContent["required-version"];
 }
+
+export function getPythonVersionFromPyProject(
+  filePath: string,
+): string | undefined {
+  if (!fs.existsSync(filePath)) {
+    core.warning(`Could not find pyproject.toml file: ${filePath}`);
+    return undefined;
+  }
+
+  let pythonVersionConstraint: string | undefined;
+  try {
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const tomlContent = toml.parse(fileContent) as {
+      tool?: { uv?: { "requires-python"?: string } };
+    };
+
+    pythonVersionConstraint = tomlContent?.tool?.uv?.["requires-python"];
+
+    if (pythonVersionConstraint) {
+      core.info(`Extracted Python version constraint from ${filePath}: ${pythonVersionConstraint}`);
+    }
+  } catch (err) {
+    const message = (err as Error).message;
+    core.warning(`Error while parsing ${filePath} for Python version: ${message}`);
+  }
+
+  return pythonVersionConstraint;
+}


### PR DESCRIPTION
This PR attempts to fix the issue where `setup-uv` does not correctly set up the Python version when `pyproject.toml` is specified and Python should be automatically determined from this file. As described in #283.

This is achieved by:
- Using `uv python pin` to correctly pin Python versions
- Extracting the pinned version from `.python-version` to ensure `UV_PYTHON` is set before activating venv

Let me know what you think. Feedback is very welcome :)

Closes #283
