### PR TITLE
📚 Document automatically enabled cache on GitHub-hosted runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ are automatically verified by this action. The sha256 hashes can be found on the
 
 If you enable caching, the [uv cache](https://docs.astral.sh/uv/concepts/cache/) will be uploaded to
 the GitHub Actions cache. This can speed up runs that reuse the cache by several minutes.
+Caching is enabled by default on GitHub-hosted runners.
 
 > [!TIP]
 >


### PR DESCRIPTION
Default behavior of caching is "auto", meaning it's enabled on github-hosted runners. This wasn't obvious at first, and I was wondering why I was getting warnings about cache when I didn't even have it enabled. Hopefully this small documentation update will save some headaches (for those who read the docs at least 😉)