### PR TITLE
Change default cache-dependency-glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ changes. If you use relative paths, they are relative to the repository root.
 > The default is
 > ```yaml
 > cache-dependency-glob: |
->   **/requirements*.txt
+>   **/*(requirements|constraints)*.(txt|in)
+>   **/pyproject.toml
 >   **/uv.lock
 > ```
 

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,9 @@ inputs:
       "Glob pattern to match files relative to the repository root to control
       the cache."
     default: |
+      **/*(requirements|constraints)*.(txt|in)
+      **/pyproject.toml
       **/uv.lock
-      **/requirements*.txt
   cache-suffix:
     description: "Suffix for the cache key"
     required: false


### PR DESCRIPTION
To support more users by default we should support popular dependency file formats. A quick GitHub search shows ~40k uses of `constraint.txt` and ~16k uses of `requirements.in`.

Closes: #261