### PR TITLE
Fix default cache dependency glob

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,8 @@ jobs:
             exit 1
           fi
         shell: bash
+      - run: uv sync
+        working-directory: __tests__/fixtures/uv-project
 
   test-activate-environment:
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -210,7 +210,10 @@ changes. If you use relative paths, they are relative to the repository root.
 > The default is
 > ```yaml
 > cache-dependency-glob: |
->   **/*(requirements|constraints)*.(txt|in)
+>   **/*requirements*.txt
+>   **/*requirements*.in
+>   **/*constraints*.txt
+>   **/*constraints*.in
 >   **/pyproject.toml
 >   **/uv.lock
 > ```

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,10 @@ inputs:
       "Glob pattern to match files relative to the repository root to control
       the cache."
     default: |
-      **/*(requirements|constraints)*.(txt|in)
+      **/*requirements*.txt
+      **/*requirements*.in
+      **/*constraints*.txt
+      **/*constraints*.in
       **/pyproject.toml
       **/uv.lock
   cache-suffix:


### PR DESCRIPTION
The new default in v6 used illegal patterns and therefore didn't match requirements files

Fixes: #385