### PR TITLE
Add section to README explaining if packages are installed by setup-uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ Running `actions/checkout` after `setup-uv` **is not supported**.
 ### Does `setup-uv` also install my project or its dependencies automatically?
 
 No, `setup-uv` alone wont install any libraries from your `pyproject.toml` or `requirements.txt`, it only sets up `uv`.  
-You should run `uv sync`, `uv pip install .`, or use `uv run ...` to have your project and its dependencies installed.
+You should run `uv sync` or `uv pip install .` separately, or use `uv run ...` to ensure necessary dependencies are installed.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ This will override any python version specifications in `pyproject.toml` and `.p
 - name: Install the latest version of uv and set the python version to 3.13t
   uses: astral-sh/setup-uv@v6
   with:
-    python-version: 3.13t
-- run: uv pip install --python=3.13t pip
+    python-version: 3.13
+- run: uv pip install --python=3.13 pip
 ```
 
 You can combine this with a matrix to test multiple python versions:
@@ -487,6 +487,11 @@ Some workflows need uv but do not need to access the repository content.
 
 But **if** you need to access the repository content, you have run `actions/checkout` before running `setup-uv`.
 Running `actions/checkout` after `setup-uv` **is not supported**.
+
+### Does `setup-uv` also install my project or its dependencies automatically?
+
+No, `setup-uv` alone wont install any libraries from your `pyproject.toml` or `requirements.txt`, it only sets up `uv`.  
+You should run `uv sync`, `uv pip install .`, or use `uv run ...` to have your project and its dependencies installed.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ This will override any python version specifications in `pyproject.toml` and `.p
 - name: Install the latest version of uv and set the python version to 3.13t
   uses: astral-sh/setup-uv@v6
   with:
-    python-version: 3.13
-- run: uv pip install --python=3.13 pip
+    python-version: 3.13t
+- run: uv pip install --python=3.13t pip
 ```
 
 You can combine this with a matrix to test multiple python versions:


### PR DESCRIPTION
Fixes #397

Also fixes what I think is a typo further up in the doc (I cant find anything about a python `3.13t` distribution anywhere online). If `3.13t` is intentional no worries, I can remove that change from the PR.

Thanks!