### PR TITLE
Set expected cache dir drive to C: on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -422,7 +422,7 @@ jobs:
           - os: ubuntu-latest
             expected-cache-dir: "/home/runner/work/_temp/setup-uv-cache"
           - os: windows-latest
-            expected-cache-dir: "D:\\a\\_temp\\setup-uv-cache"
+            expected-cache-dir: "C:\\a\\_temp\\setup-uv-cache"
           - os: selfhosted-ubuntu-arm64
             expected-cache-dir: "/home/ubuntu/.cache/uv"
     runs-on: ${{ matrix.inputs.os }}


### PR DESCRIPTION
Seems like the temp folder got moved to the C: drive