### PR TITLE
Use latest version from manifest-file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -540,7 +540,6 @@ jobs:
       - name: Install from custom manifest file
         uses: ./
         with:
-          version: 0.7.12-alpha.1
           manifest-file: "https://raw.githubusercontent.com/astral-sh/setup-uv/${{ github.ref }}/__tests__/download/custom-manifest.json"
       - run: uv sync
         working-directory: __tests__/fixtures/uv-project

--- a/README.md
+++ b/README.md
@@ -430,6 +430,11 @@ This is useful if you maintain your own uv builds or want to override the defaul
     manifest-file: "https://example.com/my-custom-manifest.json"
 ```
 
+> [!NOTE]
+> When you use a custom manifest file and do not set the `version` input, its default value is `latest`.
+> This means the action will install the latest version available in the custom manifest file.
+> This is different from the default behavior of installing the latest version from the official uv releases.
+
 ## How it works
 
 This action downloads uv from the uv repo's official

--- a/src/download/download-version.ts
+++ b/src/download/download-version.ts
@@ -7,7 +7,10 @@ import { OWNER, REPO, TOOL_CACHE_NAME } from "../utils/constants";
 import type { Architecture, Platform } from "../utils/platforms";
 import { validateChecksum } from "./checksum/checksum";
 import { Octokit } from "../utils/octokit";
-import { getDownloadUrl } from "./version-manifest";
+import {
+  getDownloadUrl,
+  getLatestKnownVersion as getLatestVersionInManifest,
+} from "./version-manifest";
 
 export function tryGetFromToolCache(
   arch: Architecture,
@@ -127,13 +130,22 @@ function getExtension(platform: Platform): string {
 
 export async function resolveVersion(
   versionInput: string,
+  manifestFile: string | undefined,
   githubToken: string,
 ): Promise<string> {
   core.debug(`Resolving version: ${versionInput}`);
-  const version =
-    versionInput === "latest"
-      ? await getLatestVersion(githubToken)
-      : versionInput;
+  let version: string;
+  if (manifestFile) {
+    version =
+      versionInput === "latest"
+        ? await getLatestVersionInManifest(manifestFile)
+        : versionInput;
+  } else {
+    version =
+      versionInput === "latest"
+        ? await getLatestVersion(githubToken)
+        : versionInput;
+  }
   if (tc.isExplicitVersion(version)) {
     core.debug(`Version ${version} is an explicit version.`);
     return version;

--- a/src/setup-uv.ts
+++ b/src/setup-uv.ts
@@ -87,7 +87,7 @@ async function setupUv(
   checkSum: string | undefined,
   githubToken: string,
 ): Promise<{ uvDir: string; version: string }> {
-  const resolvedVersion = await determineVersion();
+  const resolvedVersion = await determineVersion(manifestFile);
   const toolCacheResult = tryGetFromToolCache(arch, resolvedVersion);
   if (toolCacheResult.installedPath) {
     core.info(`Found uv in tool-cache for ${toolCacheResult.version}`);
@@ -127,9 +127,11 @@ async function setupUv(
   };
 }
 
-async function determineVersion(): Promise<string> {
+async function determineVersion(
+  manifestFile: string | undefined,
+): Promise<string> {
   if (versionInput !== "") {
-    return await resolveVersion(versionInput, githubToken);
+    return await resolveVersion(versionInput, manifestFile, githubToken);
   }
   const versionFromUvToml = getUvVersionFromConfigFile(
     `${workingDirectory}${path.sep}uv.toml`,
@@ -144,6 +146,7 @@ async function determineVersion(): Promise<string> {
   }
   return await resolveVersion(
     versionFromUvToml || versionFromPyproject || "latest",
+    manifestFile,
     githubToken,
   );
 }


### PR DESCRIPTION
If a manifest-file is supplied the default value of the version input (latest) will get the latest version available in the manifest. That might not be the actual latest version available in the official uv repo.