### PR TITLE
Do not warn when version not in manifest-file

### DIFF
--- a/src/download/download-version.ts
+++ b/src/download/download-version.ts
@@ -64,7 +64,7 @@ export async function downloadVersionFromManifest(
     platform,
   );
   if (!downloadUrl) {
-    core.warning(
+    core.info(
       `manifest-file does not contain version ${version}, arch ${arch}, platform ${platform}. Falling back to GitHub releases.`,
     );
     return await downloadVersionFromGithub(


### PR DESCRIPTION
This will spam the GitHub summary with warnings as soon as a new version is released and no new setup-uv version containing this version in the distributed manifest-file is released

Closes: #461