### PR TITLE
Fix: Prevent matching package names starting with 'uv' in dependency parsing

### DIFF
--- a/src/version/requirements-file.ts
+++ b/src/version/requirements-file.ts
@@ -15,8 +15,8 @@ function getUvVersionFromAllDependencies(
   allDependencies: string[],
 ): string | undefined {
   return allDependencies
-    .find((dep: string) => dep.startsWith("uv"))
-    ?.match(/^uv([^A-Z0-9._-]+.*)$/)?.[1]
+    .find((dep: string) => dep.match(/^uv[=<>~!]/))
+    ?.match(/^uv([=<>~!]+.*)$/)?.[1]
     .trim();
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in #486 where packages starting with 'uv' (like 'uvicorn', 'uvloop') were incorrectly being parsed as uv version specifications.

## The Problem

The current code uses `dep.startsWith("uv")` which matches any package name starting with 'uv', not just the 'uv' package itself. This causes:
- `uvicorn==0.35.0` to be parsed as `icorn==0.35.0` 
- `uvloop==0.19.0` to be parsed as `loop==0.19.0`
- Any other package starting with 'uv' to be incorrectly interpreted

## The Solution

Changed the matching logic to only match dependencies that start with 'uv' followed immediately by a version specifier character (`=`, `<`, `>`, `~`, `\!`):

```javascript
// Before
.find((dep: string) => dep.startsWith("uv"))

// After  
.find((dep: string) => dep.match(/^uv[=<>~\!]/))
```

This ensures we only match actual 'uv' package specifications like:
- ✅ `uv==0.35.0`
- ✅ `uv>=0.35.0`
- ✅ `uv~=0.35.0`

And correctly ignores other packages:
- ❌ `uvicorn==0.35.0`
- ❌ `uvloop==0.19.0`
- ❌ `uv-tool==1.0.0`

## Testing

The existing test with `uv==0.6.17` continues to work correctly. This fix prevents false positives from other packages.

Fixes the issue reported where GitHub Actions were failing with:
```
Found version for uv in /path/to/pyproject.toml: icorn==0.35.0
No version found for icorn==0.35.0
```