### PR TITLE
Add **/*.py.lock to cache-dependency-glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ changes. If you use relative paths, they are relative to the repository root.
 >   **/*constraints*.in
 >   **/pyproject.toml
 >   **/uv.lock
+>   **/*.py.lock
 > ```
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,7 @@ inputs:
       **/*constraints*.in
       **/pyproject.toml
       **/uv.lock
+      **/*.py.lock
   restore-cache:
     description: "Whether to restore the cache if found."
     default: "true"


### PR DESCRIPTION
This means uv scripts will be covered by default

Fixes https://github.com/astral-sh/setup-uv/issues/586