### PR TITLE
Correct description of `cache-dependency-glob`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     default: "auto"
   cache-dependency-glob:
     description:
-      "Glob pattern to match files relative to the repository root to control
+      "Glob pattern to match files relative to the working directory to control
       the cache."
     default: |
       **/*requirements*.txt

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -41,7 +41,7 @@ use it in subsequent steps. For example, to use the cache in the above case:
 
 If you want to control when the GitHub Actions cache is invalidated, specify a glob pattern with the
 `cache-dependency-glob` input. The GitHub Actions cache will be invalidated if any file matching the glob pattern
-changes. If you use relative paths, they are relative to the repository root.
+changes. If you use relative paths, they are relative to the working directory.
 
 > [!NOTE]
 >


### PR DESCRIPTION
As per the sole commit:

> When `working-directory` is set, paths in `cache-dependency-glob` are relative to it.