### PR TITLE
chore: use `npm ci --ignore-scripts` everywhere

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@ src/
 #### 1. Install Dependencies
 
 ```bash
-npm install
+npm ci --ignore-scripts
 ```
 
 **Timing**: ~20-30 seconds
@@ -236,7 +236,7 @@ This file is the authoritative source for understanding available action paramet
 
 ### Build Failures
 
-- **"Module not found"**: Run `npm install` to ensure dependencies are installed
+- **"Module not found"**: Run `npm ci --ignore-scripts` to ensure dependencies are installed
 - **TypeScript errors**: Check `tsconfig.json` and ensure all imports are valid
 - **Test failures**: Check if test fixtures have been modified or if logic changes broke assumptions
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: |
-          npm install
+          npm ci --ignore-scripts
       - run: |
           npm run all
       - name: Check all jobs are in all-tests-passed.needs

--- a/.github/workflows/update-known-versions.yml
+++ b/.github/workflows/update-known-versions.yml
@@ -39,7 +39,7 @@ jobs:
           fi
       - name: Compile changes
         if: ${{ steps.changes-exist.outputs.changes-exist == 'true' }}
-        run: npm ci && npm run all
+        run: npm ci --ignore-scripts && npm run all
       - name: Commit and push changes
         if: ${{ steps.changes-exist.outputs.changes-exist == 'true' }}
         id: commit-and-push


### PR DESCRIPTION
Like https://github.com/astral-sh/ruff-action/pull/276 🙂 

This also adds cooldown stanzas to the Dependabot updater rules: this ensures that we only receive dependency bumps once they're at least a week old, which should reduce the window of opportunity for an attacker who temporarily compromises popular packages (like with "Shai-Hulud" last week).