### PR TITLE
Add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g., 8.1.0)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version must match MAJOR.MINOR.PATCH (e.g., 8.1.0)"
+            exit 1
+          fi
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ inputs.version }}
+        run: |
+          RELEASE_JSON=$(gh release view "$TAG" --json isDraft,targetCommitish 2>&1) || {
+            echo "::error::No release found for $TAG"
+            exit 1
+          }
+
+          IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
+          TARGET=$(echo "$RELEASE_JSON" | jq -r '.targetCommitish')
+
+          if [[ "$IS_DRAFT" != "true" ]]; then
+            echo "::error::Release $TAG already exists and is not a draft"
+            exit 1
+          fi
+
+          if [[ "$TARGET" != "$GITHUB_SHA" ]]; then
+            echo "::error::Draft release target ($TARGET) does not match current commit ($GITHUB_SHA)"
+            exit 1
+          fi
+
+          echo "Publishing draft release $TAG"
+          gh release edit "$TAG" --draft=false


### PR DESCRIPTION
Uses a release workflow with environment protection for publishing releases instead of relying on user invocation.

The `release` environment can then be protected, e.g., requiring approval from another team member. We can add a tag ruleset to prevent tags from being created outside of the `release` environment.

I've never used Release drafter, but the workflow here differs from our other projects in that the release process just marks the draft release as final and adds the tag. The draft release is required, for simplicity.