### PR TITLE
fix: grant contents:write to validate-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     name: Validate release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Validate version and draft release
         env:


### PR DESCRIPTION
## Problem

The release workflow fails at the `validate-release` job because `gh release view` cannot find draft releases. This is because the job only has `contents: read` permission, but GitHub requires `contents: write` to view draft releases.

See failed run: https://github.com/astral-sh/setup-uv/actions/runs/24528604608

## Fix

Bump `validate-release` job permissions from `contents: read` to `contents: write`, matching the `release` job which already has this permission.