### PR TITLE
fix: add timeout to fetch to prevent silent hangs

### DIFF
--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -95790,10 +95790,16 @@ function getProxyAgent() {
   }
   return void 0;
 }
-var fetch = async (url2, opts) => await (0, import_undici2.fetch)(url2, {
-  dispatcher: getProxyAgent(),
-  ...opts
-});
+var fetch = async (url2, opts) => {
+  const timeoutSignal = AbortSignal.timeout(3e4);
+  const existingSignal = opts.signal;
+  const mergedSignal = existingSignal ? AbortSignal.any([timeoutSignal, existingSignal]) : timeoutSignal;
+  return await (0, import_undici2.fetch)(url2, {
+    dispatcher: getProxyAgent(),
+    ...opts,
+    signal: mergedSignal
+  });
+};
 
 // src/download/variant-selection.ts
 function selectDefaultVariant(entries, duplicateEntryDescription) {

--- a/dist/update-known-checksums/index.cjs
+++ b/dist/update-known-checksums/index.cjs
@@ -49749,10 +49749,16 @@ function getProxyAgent() {
   }
   return void 0;
 }
-var fetch = async (url, opts) => await (0, import_undici2.fetch)(url, {
-  dispatcher: getProxyAgent(),
-  ...opts
-});
+var fetch = async (url, opts) => {
+  const timeoutSignal = AbortSignal.timeout(3e4);
+  const existingSignal = opts.signal;
+  const mergedSignal = existingSignal ? AbortSignal.any([timeoutSignal, existingSignal]) : timeoutSignal;
+  return await (0, import_undici2.fetch)(url, {
+    dispatcher: getProxyAgent(),
+    ...opts,
+    signal: mergedSignal
+  });
+};
 
 // src/download/manifest.ts
 var cachedManifestData = /* @__PURE__ */ new Map();

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -14,8 +14,17 @@ export function getProxyAgent() {
   return undefined;
 }
 
-export const fetch = async (url: string, opts: RequestInit) =>
-  await undiciFetch(url, {
+export const fetch = async (url: string, opts: RequestInit) => {
+  // Merge timeout signal with any existing signal from opts
+  const timeoutSignal = AbortSignal.timeout(30_000);
+  const existingSignal = opts.signal;
+  const mergedSignal = existingSignal
+    ? AbortSignal.any([timeoutSignal, existingSignal])
+    : timeoutSignal;
+
+  return await undiciFetch(url, {
     dispatcher: getProxyAgent(),
     ...opts,
+    signal: mergedSignal,
   });
+};


### PR DESCRIPTION
Add AbortSignal.timeout(30s) to fetch requests to ensure they fail fast instead of hanging indefinitely when network issues occur. This fixes issues where the action would hang and eventually get killed by GitHub Actions without a clear error message.

Contributes to: #869