### PR TITLE
fix: report unexpected setup failures

### DIFF
--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -97406,6 +97406,22 @@ function getResolutionStrategy() {
 
 // src/setup-uv.ts
 var sourceDir = __dirname;
+function formatUnexpectedFailure(error2) {
+  if (error2 instanceof Error) {
+    return error2.stack ?? error2.message;
+  }
+  return String(error2);
+}
+function failUnexpectedly(event, error2) {
+  setFailed(`${event}: ${formatUnexpectedFailure(error2)}`);
+  process.exit(1);
+}
+process.on("uncaughtException", (error2) => {
+  failUnexpectedly("Uncaught exception", error2);
+});
+process.on("unhandledRejection", (reason) => {
+  failUnexpectedly("Unhandled promise rejection", reason);
+});
 async function getPythonVersion(inputs) {
   if (inputs.pythonVersion !== "") {
     return inputs.pythonVersion;

--- a/src/setup-uv.ts
+++ b/src/setup-uv.ts
@@ -19,6 +19,26 @@ import { resolveUvVersion } from "./version/resolve";
 
 const sourceDir = __dirname;
 
+function formatUnexpectedFailure(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+function failUnexpectedly(event: string, error: unknown): never {
+  core.setFailed(`${event}: ${formatUnexpectedFailure(error)}`);
+  process.exit(1);
+}
+
+process.on("uncaughtException", (error) => {
+  failUnexpectedly("Uncaught exception", error);
+});
+
+process.on("unhandledRejection", (reason) => {
+  failUnexpectedly("Unhandled promise rejection", reason);
+});
+
 async function getPythonVersion(inputs: SetupInputs): Promise<string> {
   if (inputs.pythonVersion !== "") {
     return inputs.pythonVersion;


### PR DESCRIPTION
## Summary
- add top-level uncaughtException and unhandledRejection handlers for the setup entrypoint
- report unexpected failures through core.setFailed with stack/context
- regenerate the committed setup bundle
Contributes to: #869