### PR TITLE
fix: report unexpected cache save failures

### DIFF
--- a/dist/save-cache/index.cjs
+++ b/dist/save-cache/index.cjs
@@ -63211,6 +63211,22 @@ function getResolutionStrategy() {
 }
 
 // src/save-cache.ts
+function formatUnexpectedFailure(error2) {
+  if (error2 instanceof Error) {
+    return error2.stack ?? error2.message;
+  }
+  return String(error2);
+}
+function failUnexpectedly(event, error2) {
+  setFailed(`${event}: ${formatUnexpectedFailure(error2)}`);
+  process.exit(1);
+}
+process.on("uncaughtException", (error2) => {
+  failUnexpectedly("Uncaught exception", error2);
+});
+process.on("unhandledRejection", (reason) => {
+  failUnexpectedly("Unhandled promise rejection", reason);
+});
 async function run() {
   try {
     const inputs = loadInputs();

--- a/src/save-cache.ts
+++ b/src/save-cache.ts
@@ -11,6 +11,26 @@ import {
 import { STATE_UV_PATH, STATE_UV_VERSION } from "./utils/constants";
 import { loadInputs, type SetupInputs } from "./utils/inputs";
 
+function formatUnexpectedFailure(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+function failUnexpectedly(event: string, error: unknown): never {
+  core.setFailed(`${event}: ${formatUnexpectedFailure(error)}`);
+  process.exit(1);
+}
+
+process.on("uncaughtException", (error) => {
+  failUnexpectedly("Uncaught exception", error);
+});
+
+process.on("unhandledRejection", (reason) => {
+  failUnexpectedly("Unhandled promise rejection", reason);
+});
+
 export async function run(): Promise<void> {
   try {
     const inputs = loadInputs();


### PR DESCRIPTION
## Summary
- add top-level uncaughtException and unhandledRejection handlers for the save-cache entrypoint
- report unexpected post-action failures through core.setFailed with stack/context
- regenerate the committed save-cache bundle

Contributes to: #874 