### PR TITLE
feat: add `download-from-astral-mirror` input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -861,6 +861,20 @@ jobs:
             exit 1
           fi
 
+  test-download-from-astral-mirror-false:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install with download-from-astral-mirror disabled
+        id: setup-uv
+        uses: ./
+        with:
+          download-from-astral-mirror: false
+      - name: Verify uv is installed
+        run: uv --version
+
   test-absolute-path:
     runs-on: ubuntu-latest
     steps:
@@ -1119,6 +1133,7 @@ jobs:
       - test-restore-cache-restore-cache-false
       - test-no-python-version
       - test-custom-manifest-file
+      - test-download-from-astral-mirror-false
       - test-absolute-path
       - test-relative-path
       - test-cache-prune-force

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Have a look under [Advanced Configuration](#advanced-configuration) for detailed
     # URL to a custom manifest file in the astral-sh/versions format
     manifest-file: ""
 
+    # Download uv from the Astral mirror instead of directly from GitHub Releases
+    download-from-astral-mirror: "true"
+
     # Add problem matchers
     add-problem-matchers: "true"
 ```

--- a/__tests__/download/download-version.test.ts
+++ b/__tests__/download/download-version.test.ts
@@ -376,6 +376,32 @@ describe("download-version", () => {
         "0.9.26",
       );
     });
+
+    it("skips the Astral mirror when downloadFromAstralMirror is false", async () => {
+      mockGetArtifact.mockResolvedValue({
+        archiveFormat: "tar.gz",
+        checksum: "abc123",
+        downloadUrl:
+          "https://github.com/astral-sh/uv/releases/download/0.9.26/uv-x86_64-unknown-linux-gnu.tar.gz",
+      });
+
+      await downloadVersion(
+        "unknown-linux-gnu",
+        "x86_64",
+        "0.9.26",
+        undefined,
+        "token",
+        undefined,
+        false,
+      );
+
+      expect(mockDownloadTool).toHaveBeenCalledWith(
+        "https://github.com/astral-sh/uv/releases/download/0.9.26/uv-x86_64-unknown-linux-gnu.tar.gz",
+        undefined,
+        "token",
+      );
+      expect(mockDownloadTool).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("rewriteToMirror", () => {

--- a/action-types.yml
+++ b/action-types.yml
@@ -52,6 +52,8 @@ inputs:
     type: string
   manifest-file:
     type: string
+  download-from-astral-mirror:
+    type: boolean
   add-problem-matchers:
     type: boolean
   resolution-strategy:

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,9 @@ inputs:
   manifest-file:
     description: "URL to a custom manifest file in the astral-sh/versions format."
     required: false
+  download-from-astral-mirror:
+    description: "Download uv from the Astral mirror instead of directly from GitHub Releases."
+    default: "true"
   add-problem-matchers:
     description: "Add problem matchers."
     default: "true"

--- a/dist/save-cache/index.cjs
+++ b/dist/save-cache/index.cjs
@@ -63211,6 +63211,22 @@ function getResolutionStrategy() {
 }
 
 // src/save-cache.ts
+function formatUnexpectedFailure(error2) {
+  if (error2 instanceof Error) {
+    return error2.stack ?? error2.message;
+  }
+  return String(error2);
+}
+function failUnexpectedly(event, error2) {
+  setFailed(`${event}: ${formatUnexpectedFailure(error2)}`);
+  process.exit(1);
+}
+process.on("uncaughtException", (error2) => {
+  failUnexpectedly("Uncaught exception", error2);
+});
+process.on("unhandledRejection", (reason) => {
+  failUnexpectedly("Unhandled promise rejection", reason);
+});
 async function run() {
   try {
     const inputs = loadInputs();

--- a/dist/save-cache/index.cjs
+++ b/dist/save-cache/index.cjs
@@ -62990,6 +62990,7 @@ function loadInputs() {
   const pythonDir = getUvPythonDir();
   const githubToken = getInput("github-token");
   const manifestFile = getManifestFile();
+  const downloadFromAstralMirror = getInput("download-from-astral-mirror") === "true";
   const addProblemMatchers = getInput("add-problem-matchers") === "true";
   const resolutionStrategy = getResolutionStrategy();
   return {
@@ -63000,6 +63001,7 @@ function loadInputs() {
     cachePython,
     cacheSuffix,
     checksum,
+    downloadFromAstralMirror,
     enableCache,
     githubToken,
     ignoreEmptyWorkdir,

--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -97057,7 +97057,7 @@ function tryGetFromToolCache(arch3, version3) {
   const installedPath = find(TOOL_CACHE_NAME, resolvedVersion, arch3);
   return { installedPath, version: resolvedVersion };
 }
-async function downloadVersion(platform2, arch3, version3, checksum, githubToken, manifestUrl) {
+async function downloadVersion(platform2, arch3, version3, checksum, githubToken, manifestUrl, downloadFromAstralMirror = true) {
   const artifact = await getArtifact(version3, arch3, platform2, manifestUrl);
   if (!artifact) {
     throw new Error(
@@ -97065,7 +97065,7 @@ async function downloadVersion(platform2, arch3, version3, checksum, githubToken
     );
   }
   const resolvedChecksum = manifestUrl === void 0 ? checksum : resolveChecksum(checksum, artifact.checksum);
-  const mirrorUrl = rewriteToMirror(artifact.downloadUrl);
+  const mirrorUrl = downloadFromAstralMirror ? rewriteToMirror(artifact.downloadUrl) : void 0;
   const downloadUrl = mirrorUrl ?? artifact.downloadUrl;
   try {
     return await downloadArtifact(
@@ -97184,6 +97184,7 @@ function loadInputs() {
   const pythonDir = getUvPythonDir();
   const githubToken = getInput("github-token");
   const manifestFile = getManifestFile();
+  const downloadFromAstralMirror = getInput("download-from-astral-mirror") === "true";
   const addProblemMatchers = getInput("add-problem-matchers") === "true";
   const resolutionStrategy = getResolutionStrategy();
   return {
@@ -97194,6 +97195,7 @@ function loadInputs() {
     cachePython,
     cacheSuffix,
     checksum,
+    downloadFromAstralMirror,
     enableCache,
     githubToken,
     ignoreEmptyWorkdir,
@@ -97518,7 +97520,8 @@ async function setupUv(inputs, platform2, arch3) {
     resolvedVersion,
     inputs.checksum,
     inputs.githubToken,
-    inputs.manifestFile
+    inputs.manifestFile,
+    inputs.downloadFromAstralMirror
   );
   return {
     uvDir: downloadResult.cachedToolDir,

--- a/src/download/download-version.ts
+++ b/src/download/download-version.ts
@@ -36,6 +36,7 @@ export async function downloadVersion(
   checksum: string | undefined,
   githubToken: string,
   manifestUrl?: string,
+  downloadFromAstralMirror = true,
 ): Promise<{ version: string; cachedToolDir: string }> {
   const artifact = await getArtifact(version, arch, platform, manifestUrl);
 
@@ -52,7 +53,9 @@ export async function downloadVersion(
       ? checksum
       : resolveChecksum(checksum, artifact.checksum);
 
-  const mirrorUrl = rewriteToMirror(artifact.downloadUrl);
+  const mirrorUrl = downloadFromAstralMirror
+    ? rewriteToMirror(artifact.downloadUrl)
+    : undefined;
   const downloadUrl = mirrorUrl ?? artifact.downloadUrl;
 
   try {

--- a/src/save-cache.ts
+++ b/src/save-cache.ts
@@ -11,6 +11,26 @@ import {
 import { STATE_UV_PATH, STATE_UV_VERSION } from "./utils/constants";
 import { loadInputs, type SetupInputs } from "./utils/inputs";
 
+function formatUnexpectedFailure(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+function failUnexpectedly(event: string, error: unknown): never {
+  core.setFailed(`${event}: ${formatUnexpectedFailure(error)}`);
+  process.exit(1);
+}
+
+process.on("uncaughtException", (error) => {
+  failUnexpectedly("Uncaught exception", error);
+});
+
+process.on("unhandledRejection", (reason) => {
+  failUnexpectedly("Unhandled promise rejection", reason);
+});
+
 export async function run(): Promise<void> {
   try {
     const inputs = loadInputs();

--- a/src/setup-uv.ts
+++ b/src/setup-uv.ts
@@ -154,6 +154,7 @@ async function setupUv(
     inputs.checksum,
     inputs.githubToken,
     inputs.manifestFile,
+    inputs.downloadFromAstralMirror,
   );
 
   return {

--- a/src/utils/inputs.ts
+++ b/src/utils/inputs.ts
@@ -40,6 +40,7 @@ export interface SetupInputs {
   pythonDir: string;
   githubToken: string;
   manifestFile?: string;
+  downloadFromAstralMirror: boolean;
   addProblemMatchers: boolean;
   resolutionStrategy: ResolutionStrategy;
 }
@@ -73,6 +74,8 @@ export function loadInputs(): SetupInputs {
   const pythonDir = getUvPythonDir();
   const githubToken = core.getInput("github-token");
   const manifestFile = getManifestFile();
+  const downloadFromAstralMirror =
+    core.getInput("download-from-astral-mirror") === "true";
   const addProblemMatchers = core.getInput("add-problem-matchers") === "true";
   const resolutionStrategy = getResolutionStrategy();
 
@@ -84,6 +87,7 @@ export function loadInputs(): SetupInputs {
     cachePython,
     cacheSuffix,
     checksum,
+    downloadFromAstralMirror,
     enableCache,
     githubToken,
     ignoreEmptyWorkdir,


### PR DESCRIPTION
## Summary

Add a new boolean input `download-from-astral-mirror` (default: `true`) that controls whether uv is downloaded from the Astral mirror or directly from GitHub Releases.

When set to `false`, the mirror rewrite is skipped entirely and the download goes straight to GitHub Releases.

Closes: #870 