### PR TITLE
Add quiet input to suppress info-level log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Have a look under [Advanced Configuration](#advanced-configuration) for detailed
 
     # Add problem matchers
     add-problem-matchers: "true"
+
+    # Suppress info-level log output. Only warnings and errors are shown
+    quiet: "false"
 ```
 
 ### Outputs

--- a/action-types.yml
+++ b/action-types.yml
@@ -56,6 +56,8 @@ inputs:
     type: boolean
   add-problem-matchers:
     type: boolean
+  quiet:
+    type: boolean
   resolution-strategy:
     type: enum
     allowed-values:

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,9 @@ inputs:
   add-problem-matchers:
     description: "Add problem matchers."
     default: "true"
+  quiet:
+    description: "Suppress info-level log output. Only warnings and errors are shown."
+    default: "false"
   resolution-strategy:
     description: "Resolution strategy to use when resolving version ranges. 'highest' uses the latest compatible version, 'lowest' uses the oldest compatible version."
     default: "highest"

--- a/dist/save-cache/index.cjs
+++ b/dist/save-cache/index.cjs
@@ -133,7 +133,7 @@ var require_tunnel = __commonJS({
         connectOptions.headers = connectOptions.headers || {};
         connectOptions.headers["Proxy-Authorization"] = "Basic " + new Buffer(connectOptions.proxyAuth).toString("base64");
       }
-      debug2("making CONNECT request");
+      debug3("making CONNECT request");
       var connectReq = self2.request(connectOptions);
       connectReq.useChunkedEncodingByDefault = false;
       connectReq.once("response", onResponse);
@@ -153,7 +153,7 @@ var require_tunnel = __commonJS({
         connectReq.removeAllListeners();
         socket.removeAllListeners();
         if (res.statusCode !== 200) {
-          debug2(
+          debug3(
             "tunneling socket could not be established, statusCode=%d",
             res.statusCode
           );
@@ -165,7 +165,7 @@ var require_tunnel = __commonJS({
           return;
         }
         if (head.length > 0) {
-          debug2("got illegal response body from proxy");
+          debug3("got illegal response body from proxy");
           socket.destroy();
           var error2 = new Error("got illegal response body from proxy");
           error2.code = "ECONNRESET";
@@ -173,13 +173,13 @@ var require_tunnel = __commonJS({
           self2.removeSocket(placeholder);
           return;
         }
-        debug2("tunneling connection has established");
+        debug3("tunneling connection has established");
         self2.sockets[self2.sockets.indexOf(placeholder)] = socket;
         return cb(socket);
       }
       function onError(cause) {
         connectReq.removeAllListeners();
-        debug2(
+        debug3(
           "tunneling socket could not be established, cause=%s\n",
           cause.message,
           cause.stack
@@ -241,9 +241,9 @@ var require_tunnel = __commonJS({
       }
       return target;
     }
-    var debug2;
+    var debug3;
     if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-      debug2 = function() {
+      debug3 = function() {
         var args = Array.prototype.slice.call(arguments);
         if (typeof args[0] === "string") {
           args[0] = "TUNNEL: " + args[0];
@@ -253,10 +253,10 @@ var require_tunnel = __commonJS({
         console.error.apply(console, args);
       };
     } else {
-      debug2 = function() {
+      debug3 = function() {
       };
     }
-    exports2.debug = debug2;
+    exports2.debug = debug3;
   }
 });
 
@@ -18936,7 +18936,7 @@ var require_minimatch = __commonJS({
       }
       this.parseNegate();
       var set = this.globSet = this.braceExpand();
-      if (options.debug) this.debug = function debug2() {
+      if (options.debug) this.debug = function debug3() {
         console.error.apply(console, arguments);
       };
       this.debug(this.pattern, set);
@@ -19414,9 +19414,9 @@ var require_constants6 = __commonJS({
 var require_debug = __commonJS({
   "node_modules/@actions/cache/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
-    var debug2 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
+    var debug3 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
-    module2.exports = debug2;
+    module2.exports = debug3;
   }
 });
 
@@ -19429,7 +19429,7 @@ var require_re = __commonJS({
       MAX_SAFE_BUILD_LENGTH,
       MAX_LENGTH
     } = require_constants6();
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     exports2 = module2.exports = {};
     var re = exports2.re = [];
     var safeRe = exports2.safeRe = [];
@@ -19452,7 +19452,7 @@ var require_re = __commonJS({
     var createToken = (name, value, isGlobal) => {
       const safe = makeSafeRegex(value);
       const index = R++;
-      debug2(name, index, value);
+      debug3(name, index, value);
       t[name] = index;
       src[index] = value;
       safeSrc[index] = safe;
@@ -19556,7 +19556,7 @@ var require_identifiers = __commonJS({
 var require_semver = __commonJS({
   "node_modules/@actions/cache/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants6();
     var { safeRe: re, t } = require_re();
     var parseOptions = require_parse_options();
@@ -19578,7 +19578,7 @@ var require_semver = __commonJS({
             `version is longer than ${MAX_LENGTH} characters`
           );
         }
-        debug2("SemVer", version3, options);
+        debug3("SemVer", version3, options);
         this.options = options;
         this.loose = !!options.loose;
         this.includePrerelease = !!options.includePrerelease;
@@ -19626,7 +19626,7 @@ var require_semver = __commonJS({
         return this.version;
       }
       compare(other) {
-        debug2("SemVer.compare", this.version, this.options, other);
+        debug3("SemVer.compare", this.version, this.options, other);
         if (!(other instanceof _SemVer)) {
           if (typeof other === "string" && other === this.version) {
             return 0;
@@ -19677,7 +19677,7 @@ var require_semver = __commonJS({
         do {
           const a = this.prerelease[i];
           const b = other.prerelease[i];
-          debug2("prerelease compare", i, a, b);
+          debug3("prerelease compare", i, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -19699,7 +19699,7 @@ var require_semver = __commonJS({
         do {
           const a = this.build[i];
           const b = other.build[i];
-          debug2("build compare", i, a, b);
+          debug3("build compare", i, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -20327,21 +20327,21 @@ var require_range = __commonJS({
         const loose = this.options.loose;
         const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
         range2 = range2.replace(hr, hyphenReplace(this.options.includePrerelease));
-        debug2("hyphen replace", range2);
+        debug3("hyphen replace", range2);
         range2 = range2.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
-        debug2("comparator trim", range2);
+        debug3("comparator trim", range2);
         range2 = range2.replace(re[t.TILDETRIM], tildeTrimReplace);
-        debug2("tilde trim", range2);
+        debug3("tilde trim", range2);
         range2 = range2.replace(re[t.CARETTRIM], caretTrimReplace);
-        debug2("caret trim", range2);
+        debug3("caret trim", range2);
         let rangeList = range2.split(" ").map((comp26) => parseComparator(comp26, this.options)).join(" ").split(/\s+/).map((comp26) => replaceGTE0(comp26, this.options));
         if (loose) {
           rangeList = rangeList.filter((comp26) => {
-            debug2("loose invalid filter", comp26, this.options);
+            debug3("loose invalid filter", comp26, this.options);
             return !!comp26.match(re[t.COMPARATORLOOSE]);
           });
         }
-        debug2("range list", rangeList);
+        debug3("range list", rangeList);
         const rangeMap = /* @__PURE__ */ new Map();
         const comparators = rangeList.map((comp26) => new Comparator(comp26, this.options));
         for (const comp26 of comparators) {
@@ -20396,7 +20396,7 @@ var require_range = __commonJS({
     var cache = new LRU();
     var parseOptions = require_parse_options();
     var Comparator = require_comparator();
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     var SemVer = require_semver();
     var {
       safeRe: re,
@@ -20422,15 +20422,15 @@ var require_range = __commonJS({
     };
     var parseComparator = (comp26, options) => {
       comp26 = comp26.replace(re[t.BUILD], "");
-      debug2("comp", comp26, options);
+      debug3("comp", comp26, options);
       comp26 = replaceCarets(comp26, options);
-      debug2("caret", comp26);
+      debug3("caret", comp26);
       comp26 = replaceTildes(comp26, options);
-      debug2("tildes", comp26);
+      debug3("tildes", comp26);
       comp26 = replaceXRanges(comp26, options);
-      debug2("xrange", comp26);
+      debug3("xrange", comp26);
       comp26 = replaceStars(comp26, options);
-      debug2("stars", comp26);
+      debug3("stars", comp26);
       return comp26;
     };
     var isX = (id) => !id || id.toLowerCase() === "x" || id === "*";
@@ -20440,7 +20440,7 @@ var require_range = __commonJS({
     var replaceTilde = (comp26, options) => {
       const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
       return comp26.replace(r, (_, M, m, p, pr) => {
-        debug2("tilde", comp26, _, M, m, p, pr);
+        debug3("tilde", comp26, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
           ret = "";
@@ -20449,12 +20449,12 @@ var require_range = __commonJS({
         } else if (isX(p)) {
           ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
         } else if (pr) {
-          debug2("replaceTilde pr", pr);
+          debug3("replaceTilde pr", pr);
           ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
         } else {
           ret = `>=${M}.${m}.${p} <${M}.${+m + 1}.0-0`;
         }
-        debug2("tilde return", ret);
+        debug3("tilde return", ret);
         return ret;
       });
     };
@@ -20462,11 +20462,11 @@ var require_range = __commonJS({
       return comp26.trim().split(/\s+/).map((c) => replaceCaret(c, options)).join(" ");
     };
     var replaceCaret = (comp26, options) => {
-      debug2("caret", comp26, options);
+      debug3("caret", comp26, options);
       const r = options.loose ? re[t.CARETLOOSE] : re[t.CARET];
       const z = options.includePrerelease ? "-0" : "";
       return comp26.replace(r, (_, M, m, p, pr) => {
-        debug2("caret", comp26, _, M, m, p, pr);
+        debug3("caret", comp26, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
           ret = "";
@@ -20479,7 +20479,7 @@ var require_range = __commonJS({
             ret = `>=${M}.${m}.0${z} <${+M + 1}.0.0-0`;
           }
         } else if (pr) {
-          debug2("replaceCaret pr", pr);
+          debug3("replaceCaret pr", pr);
           if (M === "0") {
             if (m === "0") {
               ret = `>=${M}.${m}.${p}-${pr} <${M}.${m}.${+p + 1}-0`;
@@ -20490,7 +20490,7 @@ var require_range = __commonJS({
             ret = `>=${M}.${m}.${p}-${pr} <${+M + 1}.0.0-0`;
           }
         } else {
-          debug2("no pr");
+          debug3("no pr");
           if (M === "0") {
             if (m === "0") {
               ret = `>=${M}.${m}.${p}${z} <${M}.${m}.${+p + 1}-0`;
@@ -20501,19 +20501,19 @@ var require_range = __commonJS({
             ret = `>=${M}.${m}.${p} <${+M + 1}.0.0-0`;
           }
         }
-        debug2("caret return", ret);
+        debug3("caret return", ret);
         return ret;
       });
     };
     var replaceXRanges = (comp26, options) => {
-      debug2("replaceXRanges", comp26, options);
+      debug3("replaceXRanges", comp26, options);
       return comp26.split(/\s+/).map((c) => replaceXRange(c, options)).join(" ");
     };
     var replaceXRange = (comp26, options) => {
       comp26 = comp26.trim();
       const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
       return comp26.replace(r, (ret, gtlt, M, m, p, pr) => {
-        debug2("xRange", comp26, ret, gtlt, M, m, p, pr);
+        debug3("xRange", comp26, ret, gtlt, M, m, p, pr);
         const xM = isX(M);
         const xm = xM || isX(m);
         const xp = xm || isX(p);
@@ -20560,16 +20560,16 @@ var require_range = __commonJS({
         } else if (xp) {
           ret = `>=${M}.${m}.0${pr} <${M}.${+m + 1}.0-0`;
         }
-        debug2("xRange return", ret);
+        debug3("xRange return", ret);
         return ret;
       });
     };
     var replaceStars = (comp26, options) => {
-      debug2("replaceStars", comp26, options);
+      debug3("replaceStars", comp26, options);
       return comp26.trim().replace(re[t.STAR], "");
     };
     var replaceGTE0 = (comp26, options) => {
-      debug2("replaceGTE0", comp26, options);
+      debug3("replaceGTE0", comp26, options);
       return comp26.trim().replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], "");
     };
     var hyphenReplace = (incPr) => ($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr) => {
@@ -20607,7 +20607,7 @@ var require_range = __commonJS({
       }
       if (version3.prerelease.length && !options.includePrerelease) {
         for (let i = 0; i < set.length; i++) {
-          debug2(set[i].semver);
+          debug3(set[i].semver);
           if (set[i].semver === Comparator.ANY) {
             continue;
           }
@@ -20644,7 +20644,7 @@ var require_comparator = __commonJS({
           }
         }
         comp26 = comp26.trim().split(/\s+/).join(" ");
-        debug2("comparator", comp26, options);
+        debug3("comparator", comp26, options);
         this.options = options;
         this.loose = !!options.loose;
         this.parse(comp26);
@@ -20653,7 +20653,7 @@ var require_comparator = __commonJS({
         } else {
           this.value = this.operator + this.semver.version;
         }
-        debug2("comp", this);
+        debug3("comp", this);
       }
       parse(comp26) {
         const r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
@@ -20675,7 +20675,7 @@ var require_comparator = __commonJS({
         return this.value;
       }
       test(version3) {
-        debug2("Comparator.test", version3, this.options.loose);
+        debug3("Comparator.test", version3, this.options.loose);
         if (this.semver === ANY || version3 === ANY) {
           return true;
         }
@@ -20732,7 +20732,7 @@ var require_comparator = __commonJS({
     var parseOptions = require_parse_options();
     var { safeRe: re, t } = require_re();
     var cmp = require_cmp();
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     var SemVer = require_semver();
     var Range = require_range();
   }
@@ -21456,11 +21456,11 @@ var require_common = __commonJS({
         let enableOverride = null;
         let namespacesCache;
         let enabledCache;
-        function debug2(...args) {
-          if (!debug2.enabled) {
+        function debug3(...args) {
+          if (!debug3.enabled) {
             return;
           }
-          const self2 = debug2;
+          const self2 = debug3;
           const curr = Number(/* @__PURE__ */ new Date());
           const ms = curr - (prevTime || curr);
           self2.diff = ms;
@@ -21490,12 +21490,12 @@ var require_common = __commonJS({
           const logFn = self2.log || createDebug.log;
           logFn.apply(self2, args);
         }
-        debug2.namespace = namespace;
-        debug2.useColors = createDebug.useColors();
-        debug2.color = createDebug.selectColor(namespace);
-        debug2.extend = extend2;
-        debug2.destroy = createDebug.destroy;
-        Object.defineProperty(debug2, "enabled", {
+        debug3.namespace = namespace;
+        debug3.useColors = createDebug.useColors();
+        debug3.color = createDebug.selectColor(namespace);
+        debug3.extend = extend2;
+        debug3.destroy = createDebug.destroy;
+        Object.defineProperty(debug3, "enabled", {
           enumerable: true,
           configurable: false,
           get: () => {
@@ -21513,9 +21513,9 @@ var require_common = __commonJS({
           }
         });
         if (typeof createDebug.init === "function") {
-          createDebug.init(debug2);
+          createDebug.init(debug3);
         }
-        return debug2;
+        return debug3;
       }
       function extend2(namespace, delimiter3) {
         const newDebug = createDebug(this.namespace + (typeof delimiter3 === "undefined" ? ":" : delimiter3) + namespace);
@@ -22025,11 +22025,11 @@ var require_node = __commonJS({
     function load() {
       return process.env.DEBUG;
     }
-    function init(debug2) {
-      debug2.inspectOpts = {};
+    function init(debug3) {
+      debug3.inspectOpts = {};
       const keys = Object.keys(exports2.inspectOpts);
       for (let i = 0; i < keys.length; i++) {
-        debug2.inspectOpts[keys[i]] = exports2.inspectOpts[keys[i]];
+        debug3.inspectOpts[keys[i]] = exports2.inspectOpts[keys[i]];
       }
     }
     module2.exports = require_common()(exports2);
@@ -22292,7 +22292,7 @@ var require_parse_proxy_response = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.parseProxyResponse = void 0;
     var debug_1 = __importDefault(require_src());
-    var debug2 = (0, debug_1.default)("https-proxy-agent:parse-proxy-response");
+    var debug3 = (0, debug_1.default)("https-proxy-agent:parse-proxy-response");
     function parseProxyResponse(socket) {
       return new Promise((resolve2, reject) => {
         let buffersLength = 0;
@@ -22311,12 +22311,12 @@ var require_parse_proxy_response = __commonJS({
         }
         function onend() {
           cleanup();
-          debug2("onend");
+          debug3("onend");
           reject(new Error("Proxy connection ended before receiving CONNECT response"));
         }
         function onerror(err) {
           cleanup();
-          debug2("onerror %o", err);
+          debug3("onerror %o", err);
           reject(err);
         }
         function ondata(b) {
@@ -22325,7 +22325,7 @@ var require_parse_proxy_response = __commonJS({
           const buffered = Buffer.concat(buffers, buffersLength);
           const endOfHeaders = buffered.indexOf("\r\n\r\n");
           if (endOfHeaders === -1) {
-            debug2("have not received end of HTTP headers yet...");
+            debug3("have not received end of HTTP headers yet...");
             read();
             return;
           }
@@ -22358,7 +22358,7 @@ var require_parse_proxy_response = __commonJS({
               headers[key] = value;
             }
           }
-          debug2("got proxy server response: %o %o", firstLine, headers);
+          debug3("got proxy server response: %o %o", firstLine, headers);
           cleanup();
           resolve2({
             connect: {
@@ -22421,7 +22421,7 @@ var require_dist2 = __commonJS({
     var agent_base_1 = require_dist();
     var url_1 = require("url");
     var parse_proxy_response_1 = require_parse_proxy_response();
-    var debug2 = (0, debug_1.default)("https-proxy-agent");
+    var debug3 = (0, debug_1.default)("https-proxy-agent");
     var setServernameFromNonIpHost = (options) => {
       if (options.servername === void 0 && options.host && !net.isIP(options.host)) {
         return {
@@ -22437,7 +22437,7 @@ var require_dist2 = __commonJS({
         this.options = { path: void 0 };
         this.proxy = typeof proxy === "string" ? new url_1.URL(proxy) : proxy;
         this.proxyHeaders = opts?.headers ?? {};
-        debug2("Creating new HttpsProxyAgent instance: %o", this.proxy.href);
+        debug3("Creating new HttpsProxyAgent instance: %o", this.proxy.href);
         const host = (this.proxy.hostname || this.proxy.host).replace(/^\[|\]$/g, "");
         const port = this.proxy.port ? parseInt(this.proxy.port, 10) : this.proxy.protocol === "https:" ? 443 : 80;
         this.connectOpts = {
@@ -22459,10 +22459,10 @@ var require_dist2 = __commonJS({
         }
         let socket;
         if (proxy.protocol === "https:") {
-          debug2("Creating `tls.Socket`: %o", this.connectOpts);
+          debug3("Creating `tls.Socket`: %o", this.connectOpts);
           socket = tls.connect(setServernameFromNonIpHost(this.connectOpts));
         } else {
-          debug2("Creating `net.Socket`: %o", this.connectOpts);
+          debug3("Creating `net.Socket`: %o", this.connectOpts);
           socket = net.connect(this.connectOpts);
         }
         const headers = typeof this.proxyHeaders === "function" ? this.proxyHeaders() : { ...this.proxyHeaders };
@@ -22490,7 +22490,7 @@ var require_dist2 = __commonJS({
         if (connect.statusCode === 200) {
           req.once("socket", resume);
           if (opts.secureEndpoint) {
-            debug2("Upgrading socket connection to TLS");
+            debug3("Upgrading socket connection to TLS");
             return tls.connect({
               ...omit(setServernameFromNonIpHost(opts), "host", "path", "port"),
               socket
@@ -22502,7 +22502,7 @@ var require_dist2 = __commonJS({
         const fakeSocket = new net.Socket({ writable: false });
         fakeSocket.readable = true;
         req.once("socket", (s) => {
-          debug2("Replaying proxy buffer for failed request");
+          debug3("Replaying proxy buffer for failed request");
           (0, assert_1.default)(s.listenerCount("data") > 0);
           s.push(buffered);
           s.push(null);
@@ -22570,13 +22570,13 @@ var require_dist3 = __commonJS({
     var events_1 = require("events");
     var agent_base_1 = require_dist();
     var url_1 = require("url");
-    var debug2 = (0, debug_1.default)("http-proxy-agent");
+    var debug3 = (0, debug_1.default)("http-proxy-agent");
     var HttpProxyAgent2 = class extends agent_base_1.Agent {
       constructor(proxy, opts) {
         super(opts);
         this.proxy = typeof proxy === "string" ? new url_1.URL(proxy) : proxy;
         this.proxyHeaders = opts?.headers ?? {};
-        debug2("Creating new HttpProxyAgent instance: %o", this.proxy.href);
+        debug3("Creating new HttpProxyAgent instance: %o", this.proxy.href);
         const host = (this.proxy.hostname || this.proxy.host).replace(/^\[|\]$/g, "");
         const port = this.proxy.port ? parseInt(this.proxy.port, 10) : this.proxy.protocol === "https:" ? 443 : 80;
         this.connectOpts = {
@@ -22622,21 +22622,21 @@ var require_dist3 = __commonJS({
         }
         let first;
         let endOfHeaders;
-        debug2("Regenerating stored HTTP header string for request");
+        debug3("Regenerating stored HTTP header string for request");
         req._implicitHeader();
         if (req.outputData && req.outputData.length > 0) {
-          debug2("Patching connection write() output buffer with updated header");
+          debug3("Patching connection write() output buffer with updated header");
           first = req.outputData[0].data;
           endOfHeaders = first.indexOf("\r\n\r\n") + 4;
           req.outputData[0].data = req._header + first.substring(endOfHeaders);
-          debug2("Output buffer: %o", req.outputData[0].data);
+          debug3("Output buffer: %o", req.outputData[0].data);
         }
         let socket;
         if (this.proxy.protocol === "https:") {
-          debug2("Creating `tls.Socket`: %o", this.connectOpts);
+          debug3("Creating `tls.Socket`: %o", this.connectOpts);
           socket = tls.connect(this.connectOpts);
         } else {
-          debug2("Creating `net.Socket`: %o", this.connectOpts);
+          debug3("Creating `net.Socket`: %o", this.connectOpts);
           socket = net.connect(this.connectOpts);
         }
         await (0, events_1.once)(socket, "connect");
@@ -24039,9 +24039,9 @@ var require_reflection_type_check = __commonJS({
     var reflection_info_1 = require_reflection_info();
     var oneof_1 = require_oneof();
     var ReflectionTypeCheck = class {
-      constructor(info2) {
+      constructor(info3) {
         var _a;
-        this.fields = (_a = info2.fields) !== null && _a !== void 0 ? _a : [];
+        this.fields = (_a = info3.fields) !== null && _a !== void 0 ? _a : [];
       }
       prepare() {
         if (this.data)
@@ -24287,8 +24287,8 @@ var require_reflection_json_reader = __commonJS({
     var assert_1 = require_assert();
     var reflection_long_convert_1 = require_reflection_long_convert();
     var ReflectionJsonReader = class {
-      constructor(info2) {
-        this.info = info2;
+      constructor(info3) {
+        this.info = info3;
       }
       prepare() {
         var _a;
@@ -24584,9 +24584,9 @@ var require_reflection_json_writer = __commonJS({
     var reflection_info_1 = require_reflection_info();
     var assert_1 = require_assert();
     var ReflectionJsonWriter = class {
-      constructor(info2) {
+      constructor(info3) {
         var _a;
-        this.fields = (_a = info2.fields) !== null && _a !== void 0 ? _a : [];
+        this.fields = (_a = info3.fields) !== null && _a !== void 0 ? _a : [];
       }
       /**
        * Converts the message to a JSON object, based on the field descriptors.
@@ -24839,8 +24839,8 @@ var require_reflection_binary_reader = __commonJS({
     var reflection_long_convert_1 = require_reflection_long_convert();
     var reflection_scalar_default_1 = require_reflection_scalar_default();
     var ReflectionBinaryReader = class {
-      constructor(info2) {
-        this.info = info2;
+      constructor(info3) {
+        this.info = info3;
       }
       prepare() {
         var _a;
@@ -25013,8 +25013,8 @@ var require_reflection_binary_writer = __commonJS({
     var assert_1 = require_assert();
     var pb_long_1 = require_pb_long();
     var ReflectionBinaryWriter = class {
-      constructor(info2) {
-        this.info = info2;
+      constructor(info3) {
+        this.info = info3;
       }
       prepare() {
         if (!this.fields) {
@@ -25264,9 +25264,9 @@ var require_reflection_merge_partial = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.reflectionMergePartial = void 0;
-    function reflectionMergePartial4(info2, target, source) {
+    function reflectionMergePartial4(info3, target, source) {
       let fieldValue, input = source, output;
-      for (let field of info2.fields) {
+      for (let field of info3.fields) {
         let name = field.localName;
         if (field.oneof) {
           const group = input[field.oneof];
@@ -25335,12 +25335,12 @@ var require_reflection_equals = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.reflectionEquals = void 0;
     var reflection_info_1 = require_reflection_info();
-    function reflectionEquals(info2, a, b) {
+    function reflectionEquals(info3, a, b) {
       if (a === b)
         return true;
       if (!a || !b)
         return false;
-      for (let field of info2.fields) {
+      for (let field of info3.fields) {
         let localName = field.localName;
         let val_a = field.oneof ? a[field.oneof][localName] : a[localName];
         let val_b = field.oneof ? b[field.oneof][localName] : b[localName];
@@ -28045,12 +28045,12 @@ var HttpClient = class {
         throw new Error("Client has already been disposed.");
       }
       const parsedUrl = new URL(requestUrl);
-      let info2 = this._prepareRequest(verb, parsedUrl, headers);
+      let info3 = this._prepareRequest(verb, parsedUrl, headers);
       const maxTries = this._allowRetries && RetryableHttpVerbs.includes(verb) ? this._maxRetries + 1 : 1;
       let numTries = 0;
       let response;
       do {
-        response = yield this.requestRaw(info2, data);
+        response = yield this.requestRaw(info3, data);
         if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
           let authenticationHandler;
           for (const handler of this.handlers) {
@@ -28060,7 +28060,7 @@ var HttpClient = class {
             }
           }
           if (authenticationHandler) {
-            return authenticationHandler.handleAuthentication(this, info2, data);
+            return authenticationHandler.handleAuthentication(this, info3, data);
           } else {
             return response;
           }
@@ -28083,8 +28083,8 @@ var HttpClient = class {
               }
             }
           }
-          info2 = this._prepareRequest(verb, parsedRedirectUrl, headers);
-          response = yield this.requestRaw(info2, data);
+          info3 = this._prepareRequest(verb, parsedRedirectUrl, headers);
+          response = yield this.requestRaw(info3, data);
           redirectsRemaining--;
         }
         if (!response.message.statusCode || !HttpResponseRetryCodes.includes(response.message.statusCode)) {
@@ -28113,7 +28113,7 @@ var HttpClient = class {
    * @param info
    * @param data
    */
-  requestRaw(info2, data) {
+  requestRaw(info3, data) {
     return __awaiter(this, void 0, void 0, function* () {
       return new Promise((resolve2, reject) => {
         function callbackForResult(err, res) {
@@ -28125,7 +28125,7 @@ var HttpClient = class {
             resolve2(res);
           }
         }
-        this.requestRawWithCallback(info2, data, callbackForResult);
+        this.requestRawWithCallback(info3, data, callbackForResult);
       });
     });
   }
@@ -28135,12 +28135,12 @@ var HttpClient = class {
    * @param data
    * @param onResult
    */
-  requestRawWithCallback(info2, data, onResult) {
+  requestRawWithCallback(info3, data, onResult) {
     if (typeof data === "string") {
-      if (!info2.options.headers) {
-        info2.options.headers = {};
+      if (!info3.options.headers) {
+        info3.options.headers = {};
       }
-      info2.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
+      info3.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
     }
     let callbackCalled = false;
     function handleResult(err, res) {
@@ -28149,7 +28149,7 @@ var HttpClient = class {
         onResult(err, res);
       }
     }
-    const req = info2.httpModule.request(info2.options, (msg) => {
+    const req = info3.httpModule.request(info3.options, (msg) => {
       const res = new HttpClientResponse(msg);
       handleResult(void 0, res);
     });
@@ -28161,7 +28161,7 @@ var HttpClient = class {
       if (socket) {
         socket.end();
       }
-      handleResult(new Error(`Request timeout: ${info2.options.path}`));
+      handleResult(new Error(`Request timeout: ${info3.options.path}`));
     });
     req.on("error", function(err) {
       handleResult(err);
@@ -28197,27 +28197,27 @@ var HttpClient = class {
     return this._getProxyAgentDispatcher(parsedUrl, proxyUrl);
   }
   _prepareRequest(method, requestUrl, headers) {
-    const info2 = {};
-    info2.parsedUrl = requestUrl;
-    const usingSsl = info2.parsedUrl.protocol === "https:";
-    info2.httpModule = usingSsl ? https : http;
+    const info3 = {};
+    info3.parsedUrl = requestUrl;
+    const usingSsl = info3.parsedUrl.protocol === "https:";
+    info3.httpModule = usingSsl ? https : http;
     const defaultPort = usingSsl ? 443 : 80;
-    info2.options = {};
-    info2.options.host = info2.parsedUrl.hostname;
-    info2.options.port = info2.parsedUrl.port ? parseInt(info2.parsedUrl.port) : defaultPort;
-    info2.options.path = (info2.parsedUrl.pathname || "") + (info2.parsedUrl.search || "");
-    info2.options.method = method;
-    info2.options.headers = this._mergeHeaders(headers);
+    info3.options = {};
+    info3.options.host = info3.parsedUrl.hostname;
+    info3.options.port = info3.parsedUrl.port ? parseInt(info3.parsedUrl.port) : defaultPort;
+    info3.options.path = (info3.parsedUrl.pathname || "") + (info3.parsedUrl.search || "");
+    info3.options.method = method;
+    info3.options.headers = this._mergeHeaders(headers);
     if (this.userAgent != null) {
-      info2.options.headers["user-agent"] = this.userAgent;
+      info3.options.headers["user-agent"] = this.userAgent;
     }
-    info2.options.agent = this._getAgent(info2.parsedUrl);
+    info3.options.agent = this._getAgent(info3.parsedUrl);
     if (this.handlers) {
       for (const handler of this.handlers) {
-        handler.prepareRequest(info2.options);
+        handler.prepareRequest(info3.options);
       }
     }
-    return info2;
+    return info3;
   }
   _mergeHeaders(headers) {
     if (this.requestOptions && this.requestOptions.headers) {
@@ -30601,14 +30601,14 @@ function disable() {
   return result;
 }
 function createDebugger(namespace) {
-  const newDebugger = Object.assign(debug2, {
+  const newDebugger = Object.assign(debug3, {
     enabled: enabled(namespace),
     destroy,
     log: debugObj.log,
     namespace,
     extend
   });
-  function debug2(...args) {
+  function debug3(...args) {
     if (!newDebugger.enabled) {
       return;
     }
@@ -34098,12 +34098,12 @@ function getOperationRequestInfo(request) {
   if (hasOriginalRequest(request)) {
     return getOperationRequestInfo(request[originalRequestSymbol]);
   }
-  let info2 = state2.operationRequestMap.get(request);
-  if (!info2) {
-    info2 = {};
-    state2.operationRequestMap.set(request, info2);
+  let info3 = state2.operationRequestMap.get(request);
+  if (!info3) {
+    info3 = {};
+    state2.operationRequestMap.set(request, info3);
   }
-  return info2;
+  return info3;
 }
 
 // node_modules/@azure/core-client/dist/esm/deserializationPolicy.js
@@ -62241,6 +62241,21 @@ function saveCacheV2(paths_1, key_1, options_1) {
 // src/save-cache.ts
 var pep440 = __toESM(require_pep440(), 1);
 
+// src/utils/logging.ts
+var quiet;
+function isQuiet() {
+  if (quiet === void 0) {
+    quiet = typeof getInput === "function" && getInput("quiet") === "true";
+  }
+  return quiet;
+}
+function info2(msg) {
+  if (!isQuiet()) {
+    info(msg);
+  }
+}
+var warning2 = warning;
+
 // src/cache/restore-cache.ts
 var STATE_CACHE_KEY = "cache-key";
 var STATE_CACHE_MATCHED_KEY = "cache-matched-key";
@@ -62992,6 +63007,7 @@ function loadInputs() {
   const manifestFile = getManifestFile();
   const downloadFromAstralMirror = getInput("download-from-astral-mirror") === "true";
   const addProblemMatchers = getInput("add-problem-matchers") === "true";
+  const quiet2 = getInput("quiet") === "true";
   const resolutionStrategy = getResolutionStrategy();
   return {
     activateEnvironment,
@@ -63011,6 +63027,7 @@ function loadInputs() {
     pruneCache: pruneCache2,
     pythonDir,
     pythonVersion,
+    quiet: quiet2,
     resolutionStrategy,
     restoreCache: restoreCache2,
     saveCache: saveCache4,
@@ -63034,7 +63051,7 @@ function getVenvPath(workingDirectory, activateEnvironment) {
   const venvPathInput = getInput("venv-path");
   if (venvPathInput !== "") {
     if (!activateEnvironment) {
-      warning("venv-path is only used when activate-environment is true");
+      warning2("venv-path is only used when activate-environment is true");
     }
     const tildeExpanded = expandTilde(venvPathInput);
     return normalizePath(resolveRelativePath(workingDirectory, tildeExpanded));
@@ -63097,7 +63114,7 @@ function getCacheLocalPath(workingDirectory, versionFile, enableCache) {
     return { path: cacheDirFromConfig, source: 1 /* Config */ };
   }
   if (process.env.UV_CACHE_DIR !== void 0) {
-    info(`UV_CACHE_DIR is already set to ${process.env.UV_CACHE_DIR}`);
+    info2(`UV_CACHE_DIR is already set to ${process.env.UV_CACHE_DIR}`);
     return { path: process.env.UV_CACHE_DIR, source: 2 /* Env */ };
   }
   if (enableCache) {
@@ -63130,12 +63147,12 @@ function getCacheDirFromConfig(workingDirectory, versionFile) {
     try {
       const cacheDir = getConfigValueFromTomlFile(resolvedPath, "cache-dir");
       if (cacheDir !== void 0) {
-        info(`Found cache-dir in ${resolvedPath}: ${cacheDir}`);
+        info2(`Found cache-dir in ${resolvedPath}: ${cacheDir}`);
         return cacheDir;
       }
     } catch (err) {
       const message = err.message;
-      warning(`Error while parsing ${filePath}: ${message}`);
+      warning2(`Error while parsing ${filePath}: ${message}`);
       return void 0;
     }
   }
@@ -63143,7 +63160,7 @@ function getCacheDirFromConfig(workingDirectory, versionFile) {
 }
 function getUvPythonDir() {
   if (process.env.UV_PYTHON_INSTALL_DIR !== void 0) {
-    info(
+    info2(
       `UV_PYTHON_INSTALL_DIR is already set to ${process.env.UV_PYTHON_INSTALL_DIR}`
     );
     return process.env.UV_PYTHON_INSTALL_DIR;
@@ -63236,7 +63253,7 @@ async function run() {
       if (inputs.saveCache) {
         await saveCache3(inputs);
       } else {
-        info("save-cache is false. Skipping save cache step.");
+        info2("save-cache is false. Skipping save cache step.");
       }
       await new Promise((resolve2) => setTimeout(resolve2, 100));
       process.exit(0);
@@ -63250,11 +63267,11 @@ async function saveCache3(inputs) {
   const cacheKey = getState(STATE_CACHE_KEY);
   const matchedKey = getState(STATE_CACHE_MATCHED_KEY);
   if (!cacheKey) {
-    warning("Error retrieving cache key from state.");
+    warning2("Error retrieving cache key from state.");
     return;
   }
   if (matchedKey === cacheKey) {
-    info(`Cache hit occurred on key ${cacheKey}, not saving cache.`);
+    info2(`Cache hit occurred on key ${cacheKey}, not saving cache.`);
   } else {
     if (inputs.pruneCache) {
       await pruneCache();
@@ -63262,7 +63279,7 @@ async function saveCache3(inputs) {
     const actualCachePath = getUvCachePath(inputs);
     if (!fs7.existsSync(actualCachePath)) {
       if (inputs.ignoreNothingToCache) {
-        info(
+        info2(
           "No cacheable uv cache paths were found. Ignoring because ignore-nothing-to-cache is enabled."
         );
       } else {
@@ -63281,7 +63298,7 @@ async function saveCache3(inputs) {
   }
   if (inputs.cachePython) {
     if (!fs7.existsSync(inputs.pythonDir)) {
-      warning(
+      warning2(
         `Python cache path ${inputs.pythonDir} does not exist on disk. Skipping Python cache save because no managed Python installation was found. If you want uv to install managed Python instead of using a system interpreter, set UV_PYTHON_PREFERENCE=only-managed.`
       );
       return;
@@ -63304,7 +63321,7 @@ async function pruneCache() {
   if (forceSupported) {
     execArgs.push("--force");
   }
-  info("Pruning cache...");
+  info2("Pruning cache...");
   const uvPath = getState(STATE_UV_PATH);
   await exec(uvPath, execArgs, options);
 }
@@ -63315,7 +63332,7 @@ function getUvCachePath(inputs) {
     );
   }
   if (process.env.UV_CACHE_DIR && process.env.UV_CACHE_DIR !== inputs.cacheLocalPath.path) {
-    warning(
+    warning2(
       `The environment variable UV_CACHE_DIR has been changed to "${process.env.UV_CACHE_DIR}", by an action or step running after astral-sh/setup-uv. This can lead to unexpected behavior. If you expected this to happen set the cache-local-path input to "${process.env.UV_CACHE_DIR}" instead of "${inputs.cacheLocalPath.path}".`
     );
     return process.env.UV_CACHE_DIR;
@@ -63325,14 +63342,12 @@ function getUvCachePath(inputs) {
 async function saveCacheToKey(cacheKey, cachePath, stateKey, cacheName) {
   const matchedKey = getState(stateKey);
   if (matchedKey === cacheKey) {
-    info(
-      `${cacheName} hit occurred on key ${cacheKey}, not saving cache.`
-    );
+    info2(`${cacheName} hit occurred on key ${cacheKey}, not saving cache.`);
     return;
   }
-  info(`Including ${cacheName} path: ${cachePath}`);
+  info2(`Including ${cacheName} path: ${cachePath}`);
   await saveCache2([cachePath], cacheKey);
-  info(`${cacheName} saved with key: ${cacheKey}`);
+  info2(`${cacheName} saved with key: ${cacheKey}`);
 }
 run();
 // Annotate the CommonJS export names for ESM import in node:

--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -132,7 +132,7 @@ var require_tunnel = __commonJS({
         connectOptions.headers = connectOptions.headers || {};
         connectOptions.headers["Proxy-Authorization"] = "Basic " + new Buffer(connectOptions.proxyAuth).toString("base64");
       }
-      debug2("making CONNECT request");
+      debug3("making CONNECT request");
       var connectReq = self2.request(connectOptions);
       connectReq.useChunkedEncodingByDefault = false;
       connectReq.once("response", onResponse);
@@ -152,7 +152,7 @@ var require_tunnel = __commonJS({
         connectReq.removeAllListeners();
         socket.removeAllListeners();
         if (res.statusCode !== 200) {
-          debug2(
+          debug3(
             "tunneling socket could not be established, statusCode=%d",
             res.statusCode
           );
@@ -164,7 +164,7 @@ var require_tunnel = __commonJS({
           return;
         }
         if (head.length > 0) {
-          debug2("got illegal response body from proxy");
+          debug3("got illegal response body from proxy");
           socket.destroy();
           var error2 = new Error("got illegal response body from proxy");
           error2.code = "ECONNRESET";
@@ -172,13 +172,13 @@ var require_tunnel = __commonJS({
           self2.removeSocket(placeholder);
           return;
         }
-        debug2("tunneling connection has established");
+        debug3("tunneling connection has established");
         self2.sockets[self2.sockets.indexOf(placeholder)] = socket;
         return cb(socket);
       }
       function onError(cause) {
         connectReq.removeAllListeners();
-        debug2(
+        debug3(
           "tunneling socket could not be established, cause=%s\n",
           cause.message,
           cause.stack
@@ -240,9 +240,9 @@ var require_tunnel = __commonJS({
       }
       return target;
     }
-    var debug2;
+    var debug3;
     if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-      debug2 = function() {
+      debug3 = function() {
         var args = Array.prototype.slice.call(arguments);
         if (typeof args[0] === "string") {
           args[0] = "TUNNEL: " + args[0];
@@ -252,10 +252,10 @@ var require_tunnel = __commonJS({
         console.error.apply(console, args);
       };
     } else {
-      debug2 = function() {
+      debug3 = function() {
       };
     }
-    exports2.debug = debug2;
+    exports2.debug = debug3;
   }
 });
 
@@ -18935,7 +18935,7 @@ var require_minimatch = __commonJS({
       }
       this.parseNegate();
       var set = this.globSet = this.braceExpand();
-      if (options.debug) this.debug = function debug2() {
+      if (options.debug) this.debug = function debug3() {
         console.error.apply(console, arguments);
       };
       this.debug(this.pattern, set);
@@ -19413,9 +19413,9 @@ var require_constants6 = __commonJS({
 var require_debug = __commonJS({
   "node_modules/@actions/cache/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
-    var debug2 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
+    var debug3 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
-    module2.exports = debug2;
+    module2.exports = debug3;
   }
 });
 
@@ -19428,7 +19428,7 @@ var require_re = __commonJS({
       MAX_SAFE_BUILD_LENGTH,
       MAX_LENGTH
     } = require_constants6();
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     exports2 = module2.exports = {};
     var re = exports2.re = [];
     var safeRe = exports2.safeRe = [];
@@ -19451,7 +19451,7 @@ var require_re = __commonJS({
     var createToken = (name, value, isGlobal) => {
       const safe = makeSafeRegex(value);
       const index = R++;
-      debug2(name, index, value);
+      debug3(name, index, value);
       t[name] = index;
       src[index] = value;
       safeSrc[index] = safe;
@@ -19555,7 +19555,7 @@ var require_identifiers = __commonJS({
 var require_semver = __commonJS({
   "node_modules/@actions/cache/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants6();
     var { safeRe: re, t } = require_re();
     var parseOptions = require_parse_options();
@@ -19577,7 +19577,7 @@ var require_semver = __commonJS({
             `version is longer than ${MAX_LENGTH} characters`
           );
         }
-        debug2("SemVer", version3, options);
+        debug3("SemVer", version3, options);
         this.options = options;
         this.loose = !!options.loose;
         this.includePrerelease = !!options.includePrerelease;
@@ -19625,7 +19625,7 @@ var require_semver = __commonJS({
         return this.version;
       }
       compare(other) {
-        debug2("SemVer.compare", this.version, this.options, other);
+        debug3("SemVer.compare", this.version, this.options, other);
         if (!(other instanceof _SemVer)) {
           if (typeof other === "string" && other === this.version) {
             return 0;
@@ -19676,7 +19676,7 @@ var require_semver = __commonJS({
         do {
           const a = this.prerelease[i];
           const b = other.prerelease[i];
-          debug2("prerelease compare", i, a, b);
+          debug3("prerelease compare", i, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -19698,7 +19698,7 @@ var require_semver = __commonJS({
         do {
           const a = this.build[i];
           const b = other.build[i];
-          debug2("build compare", i, a, b);
+          debug3("build compare", i, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -20326,21 +20326,21 @@ var require_range = __commonJS({
         const loose = this.options.loose;
         const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
         range2 = range2.replace(hr, hyphenReplace(this.options.includePrerelease));
-        debug2("hyphen replace", range2);
+        debug3("hyphen replace", range2);
         range2 = range2.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
-        debug2("comparator trim", range2);
+        debug3("comparator trim", range2);
         range2 = range2.replace(re[t.TILDETRIM], tildeTrimReplace);
-        debug2("tilde trim", range2);
+        debug3("tilde trim", range2);
         range2 = range2.replace(re[t.CARETTRIM], caretTrimReplace);
-        debug2("caret trim", range2);
+        debug3("caret trim", range2);
         let rangeList = range2.split(" ").map((comp26) => parseComparator(comp26, this.options)).join(" ").split(/\s+/).map((comp26) => replaceGTE0(comp26, this.options));
         if (loose) {
           rangeList = rangeList.filter((comp26) => {
-            debug2("loose invalid filter", comp26, this.options);
+            debug3("loose invalid filter", comp26, this.options);
             return !!comp26.match(re[t.COMPARATORLOOSE]);
           });
         }
-        debug2("range list", rangeList);
+        debug3("range list", rangeList);
         const rangeMap = /* @__PURE__ */ new Map();
         const comparators = rangeList.map((comp26) => new Comparator(comp26, this.options));
         for (const comp26 of comparators) {
@@ -20395,7 +20395,7 @@ var require_range = __commonJS({
     var cache = new LRU();
     var parseOptions = require_parse_options();
     var Comparator = require_comparator();
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     var SemVer = require_semver();
     var {
       safeRe: re,
@@ -20421,15 +20421,15 @@ var require_range = __commonJS({
     };
     var parseComparator = (comp26, options) => {
       comp26 = comp26.replace(re[t.BUILD], "");
-      debug2("comp", comp26, options);
+      debug3("comp", comp26, options);
       comp26 = replaceCarets(comp26, options);
-      debug2("caret", comp26);
+      debug3("caret", comp26);
       comp26 = replaceTildes(comp26, options);
-      debug2("tildes", comp26);
+      debug3("tildes", comp26);
       comp26 = replaceXRanges(comp26, options);
-      debug2("xrange", comp26);
+      debug3("xrange", comp26);
       comp26 = replaceStars(comp26, options);
-      debug2("stars", comp26);
+      debug3("stars", comp26);
       return comp26;
     };
     var isX = (id) => !id || id.toLowerCase() === "x" || id === "*";
@@ -20439,7 +20439,7 @@ var require_range = __commonJS({
     var replaceTilde = (comp26, options) => {
       const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
       return comp26.replace(r, (_, M, m, p, pr) => {
-        debug2("tilde", comp26, _, M, m, p, pr);
+        debug3("tilde", comp26, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
           ret = "";
@@ -20448,12 +20448,12 @@ var require_range = __commonJS({
         } else if (isX(p)) {
           ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
         } else if (pr) {
-          debug2("replaceTilde pr", pr);
+          debug3("replaceTilde pr", pr);
           ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
         } else {
           ret = `>=${M}.${m}.${p} <${M}.${+m + 1}.0-0`;
         }
-        debug2("tilde return", ret);
+        debug3("tilde return", ret);
         return ret;
       });
     };
@@ -20461,11 +20461,11 @@ var require_range = __commonJS({
       return comp26.trim().split(/\s+/).map((c) => replaceCaret(c, options)).join(" ");
     };
     var replaceCaret = (comp26, options) => {
-      debug2("caret", comp26, options);
+      debug3("caret", comp26, options);
       const r = options.loose ? re[t.CARETLOOSE] : re[t.CARET];
       const z = options.includePrerelease ? "-0" : "";
       return comp26.replace(r, (_, M, m, p, pr) => {
-        debug2("caret", comp26, _, M, m, p, pr);
+        debug3("caret", comp26, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
           ret = "";
@@ -20478,7 +20478,7 @@ var require_range = __commonJS({
             ret = `>=${M}.${m}.0${z} <${+M + 1}.0.0-0`;
           }
         } else if (pr) {
-          debug2("replaceCaret pr", pr);
+          debug3("replaceCaret pr", pr);
           if (M === "0") {
             if (m === "0") {
               ret = `>=${M}.${m}.${p}-${pr} <${M}.${m}.${+p + 1}-0`;
@@ -20489,7 +20489,7 @@ var require_range = __commonJS({
             ret = `>=${M}.${m}.${p}-${pr} <${+M + 1}.0.0-0`;
           }
         } else {
-          debug2("no pr");
+          debug3("no pr");
           if (M === "0") {
             if (m === "0") {
               ret = `>=${M}.${m}.${p}${z} <${M}.${m}.${+p + 1}-0`;
@@ -20500,19 +20500,19 @@ var require_range = __commonJS({
             ret = `>=${M}.${m}.${p} <${+M + 1}.0.0-0`;
           }
         }
-        debug2("caret return", ret);
+        debug3("caret return", ret);
         return ret;
       });
     };
     var replaceXRanges = (comp26, options) => {
-      debug2("replaceXRanges", comp26, options);
+      debug3("replaceXRanges", comp26, options);
       return comp26.split(/\s+/).map((c) => replaceXRange(c, options)).join(" ");
     };
     var replaceXRange = (comp26, options) => {
       comp26 = comp26.trim();
       const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
       return comp26.replace(r, (ret, gtlt, M, m, p, pr) => {
-        debug2("xRange", comp26, ret, gtlt, M, m, p, pr);
+        debug3("xRange", comp26, ret, gtlt, M, m, p, pr);
         const xM = isX(M);
         const xm = xM || isX(m);
         const xp = xm || isX(p);
@@ -20559,16 +20559,16 @@ var require_range = __commonJS({
         } else if (xp) {
           ret = `>=${M}.${m}.0${pr} <${M}.${+m + 1}.0-0`;
         }
-        debug2("xRange return", ret);
+        debug3("xRange return", ret);
         return ret;
       });
     };
     var replaceStars = (comp26, options) => {
-      debug2("replaceStars", comp26, options);
+      debug3("replaceStars", comp26, options);
       return comp26.trim().replace(re[t.STAR], "");
     };
     var replaceGTE0 = (comp26, options) => {
-      debug2("replaceGTE0", comp26, options);
+      debug3("replaceGTE0", comp26, options);
       return comp26.trim().replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], "");
     };
     var hyphenReplace = (incPr) => ($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr) => {
@@ -20606,7 +20606,7 @@ var require_range = __commonJS({
       }
       if (version3.prerelease.length && !options.includePrerelease) {
         for (let i = 0; i < set.length; i++) {
-          debug2(set[i].semver);
+          debug3(set[i].semver);
           if (set[i].semver === Comparator.ANY) {
             continue;
           }
@@ -20643,7 +20643,7 @@ var require_comparator = __commonJS({
           }
         }
         comp26 = comp26.trim().split(/\s+/).join(" ");
-        debug2("comparator", comp26, options);
+        debug3("comparator", comp26, options);
         this.options = options;
         this.loose = !!options.loose;
         this.parse(comp26);
@@ -20652,7 +20652,7 @@ var require_comparator = __commonJS({
         } else {
           this.value = this.operator + this.semver.version;
         }
-        debug2("comp", this);
+        debug3("comp", this);
       }
       parse(comp26) {
         const r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
@@ -20674,7 +20674,7 @@ var require_comparator = __commonJS({
         return this.value;
       }
       test(version3) {
-        debug2("Comparator.test", version3, this.options.loose);
+        debug3("Comparator.test", version3, this.options.loose);
         if (this.semver === ANY || version3 === ANY) {
           return true;
         }
@@ -20731,7 +20731,7 @@ var require_comparator = __commonJS({
     var parseOptions = require_parse_options();
     var { safeRe: re, t } = require_re();
     var cmp = require_cmp();
-    var debug2 = require_debug();
+    var debug3 = require_debug();
     var SemVer = require_semver();
     var Range = require_range();
   }
@@ -21455,11 +21455,11 @@ var require_common = __commonJS({
         let enableOverride = null;
         let namespacesCache;
         let enabledCache;
-        function debug2(...args) {
-          if (!debug2.enabled) {
+        function debug3(...args) {
+          if (!debug3.enabled) {
             return;
           }
-          const self2 = debug2;
+          const self2 = debug3;
           const curr = Number(/* @__PURE__ */ new Date());
           const ms = curr - (prevTime || curr);
           self2.diff = ms;
@@ -21489,12 +21489,12 @@ var require_common = __commonJS({
           const logFn = self2.log || createDebug.log;
           logFn.apply(self2, args);
         }
-        debug2.namespace = namespace;
-        debug2.useColors = createDebug.useColors();
-        debug2.color = createDebug.selectColor(namespace);
-        debug2.extend = extend2;
-        debug2.destroy = createDebug.destroy;
-        Object.defineProperty(debug2, "enabled", {
+        debug3.namespace = namespace;
+        debug3.useColors = createDebug.useColors();
+        debug3.color = createDebug.selectColor(namespace);
+        debug3.extend = extend2;
+        debug3.destroy = createDebug.destroy;
+        Object.defineProperty(debug3, "enabled", {
           enumerable: true,
           configurable: false,
           get: () => {
@@ -21512,9 +21512,9 @@ var require_common = __commonJS({
           }
         });
         if (typeof createDebug.init === "function") {
-          createDebug.init(debug2);
+          createDebug.init(debug3);
         }
-        return debug2;
+        return debug3;
       }
       function extend2(namespace, delimiter4) {
         const newDebug = createDebug(this.namespace + (typeof delimiter4 === "undefined" ? ":" : delimiter4) + namespace);
@@ -22024,11 +22024,11 @@ var require_node = __commonJS({
     function load() {
       return process.env.DEBUG;
     }
-    function init(debug2) {
-      debug2.inspectOpts = {};
+    function init(debug3) {
+      debug3.inspectOpts = {};
       const keys = Object.keys(exports2.inspectOpts);
       for (let i = 0; i < keys.length; i++) {
-        debug2.inspectOpts[keys[i]] = exports2.inspectOpts[keys[i]];
+        debug3.inspectOpts[keys[i]] = exports2.inspectOpts[keys[i]];
       }
     }
     module2.exports = require_common()(exports2);
@@ -22291,7 +22291,7 @@ var require_parse_proxy_response = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.parseProxyResponse = void 0;
     var debug_1 = __importDefault(require_src());
-    var debug2 = (0, debug_1.default)("https-proxy-agent:parse-proxy-response");
+    var debug3 = (0, debug_1.default)("https-proxy-agent:parse-proxy-response");
     function parseProxyResponse(socket) {
       return new Promise((resolve3, reject) => {
         let buffersLength = 0;
@@ -22310,12 +22310,12 @@ var require_parse_proxy_response = __commonJS({
         }
         function onend() {
           cleanup();
-          debug2("onend");
+          debug3("onend");
           reject(new Error("Proxy connection ended before receiving CONNECT response"));
         }
         function onerror(err) {
           cleanup();
-          debug2("onerror %o", err);
+          debug3("onerror %o", err);
           reject(err);
         }
         function ondata(b) {
@@ -22324,7 +22324,7 @@ var require_parse_proxy_response = __commonJS({
           const buffered = Buffer.concat(buffers, buffersLength);
           const endOfHeaders = buffered.indexOf("\r\n\r\n");
           if (endOfHeaders === -1) {
-            debug2("have not received end of HTTP headers yet...");
+            debug3("have not received end of HTTP headers yet...");
             read();
             return;
           }
@@ -22357,7 +22357,7 @@ var require_parse_proxy_response = __commonJS({
               headers[key] = value;
             }
           }
-          debug2("got proxy server response: %o %o", firstLine, headers);
+          debug3("got proxy server response: %o %o", firstLine, headers);
           cleanup();
           resolve3({
             connect: {
@@ -22420,7 +22420,7 @@ var require_dist2 = __commonJS({
     var agent_base_1 = require_dist();
     var url_1 = require("url");
     var parse_proxy_response_1 = require_parse_proxy_response();
-    var debug2 = (0, debug_1.default)("https-proxy-agent");
+    var debug3 = (0, debug_1.default)("https-proxy-agent");
     var setServernameFromNonIpHost = (options) => {
       if (options.servername === void 0 && options.host && !net.isIP(options.host)) {
         return {
@@ -22436,7 +22436,7 @@ var require_dist2 = __commonJS({
         this.options = { path: void 0 };
         this.proxy = typeof proxy === "string" ? new url_1.URL(proxy) : proxy;
         this.proxyHeaders = opts?.headers ?? {};
-        debug2("Creating new HttpsProxyAgent instance: %o", this.proxy.href);
+        debug3("Creating new HttpsProxyAgent instance: %o", this.proxy.href);
         const host = (this.proxy.hostname || this.proxy.host).replace(/^\[|\]$/g, "");
         const port = this.proxy.port ? parseInt(this.proxy.port, 10) : this.proxy.protocol === "https:" ? 443 : 80;
         this.connectOpts = {
@@ -22458,10 +22458,10 @@ var require_dist2 = __commonJS({
         }
         let socket;
         if (proxy.protocol === "https:") {
-          debug2("Creating `tls.Socket`: %o", this.connectOpts);
+          debug3("Creating `tls.Socket`: %o", this.connectOpts);
           socket = tls.connect(setServernameFromNonIpHost(this.connectOpts));
         } else {
-          debug2("Creating `net.Socket`: %o", this.connectOpts);
+          debug3("Creating `net.Socket`: %o", this.connectOpts);
           socket = net.connect(this.connectOpts);
         }
         const headers = typeof this.proxyHeaders === "function" ? this.proxyHeaders() : { ...this.proxyHeaders };
@@ -22489,7 +22489,7 @@ var require_dist2 = __commonJS({
         if (connect.statusCode === 200) {
           req.once("socket", resume);
           if (opts.secureEndpoint) {
-            debug2("Upgrading socket connection to TLS");
+            debug3("Upgrading socket connection to TLS");
             return tls.connect({
               ...omit(setServernameFromNonIpHost(opts), "host", "path", "port"),
               socket
@@ -22501,7 +22501,7 @@ var require_dist2 = __commonJS({
         const fakeSocket = new net.Socket({ writable: false });
         fakeSocket.readable = true;
         req.once("socket", (s) => {
-          debug2("Replaying proxy buffer for failed request");
+          debug3("Replaying proxy buffer for failed request");
           (0, assert_1.default)(s.listenerCount("data") > 0);
           s.push(buffered);
           s.push(null);
@@ -22569,13 +22569,13 @@ var require_dist3 = __commonJS({
     var events_1 = require("events");
     var agent_base_1 = require_dist();
     var url_1 = require("url");
-    var debug2 = (0, debug_1.default)("http-proxy-agent");
+    var debug3 = (0, debug_1.default)("http-proxy-agent");
     var HttpProxyAgent2 = class extends agent_base_1.Agent {
       constructor(proxy, opts) {
         super(opts);
         this.proxy = typeof proxy === "string" ? new url_1.URL(proxy) : proxy;
         this.proxyHeaders = opts?.headers ?? {};
-        debug2("Creating new HttpProxyAgent instance: %o", this.proxy.href);
+        debug3("Creating new HttpProxyAgent instance: %o", this.proxy.href);
         const host = (this.proxy.hostname || this.proxy.host).replace(/^\[|\]$/g, "");
         const port = this.proxy.port ? parseInt(this.proxy.port, 10) : this.proxy.protocol === "https:" ? 443 : 80;
         this.connectOpts = {
@@ -22621,21 +22621,21 @@ var require_dist3 = __commonJS({
         }
         let first;
         let endOfHeaders;
-        debug2("Regenerating stored HTTP header string for request");
+        debug3("Regenerating stored HTTP header string for request");
         req._implicitHeader();
         if (req.outputData && req.outputData.length > 0) {
-          debug2("Patching connection write() output buffer with updated header");
+          debug3("Patching connection write() output buffer with updated header");
           first = req.outputData[0].data;
           endOfHeaders = first.indexOf("\r\n\r\n") + 4;
           req.outputData[0].data = req._header + first.substring(endOfHeaders);
-          debug2("Output buffer: %o", req.outputData[0].data);
+          debug3("Output buffer: %o", req.outputData[0].data);
         }
         let socket;
         if (this.proxy.protocol === "https:") {
-          debug2("Creating `tls.Socket`: %o", this.connectOpts);
+          debug3("Creating `tls.Socket`: %o", this.connectOpts);
           socket = tls.connect(this.connectOpts);
         } else {
-          debug2("Creating `net.Socket`: %o", this.connectOpts);
+          debug3("Creating `net.Socket`: %o", this.connectOpts);
           socket = net.connect(this.connectOpts);
         }
         await (0, events_1.once)(socket, "connect");
@@ -24038,9 +24038,9 @@ var require_reflection_type_check = __commonJS({
     var reflection_info_1 = require_reflection_info();
     var oneof_1 = require_oneof();
     var ReflectionTypeCheck = class {
-      constructor(info2) {
+      constructor(info3) {
         var _a;
-        this.fields = (_a = info2.fields) !== null && _a !== void 0 ? _a : [];
+        this.fields = (_a = info3.fields) !== null && _a !== void 0 ? _a : [];
       }
       prepare() {
         if (this.data)
@@ -24286,8 +24286,8 @@ var require_reflection_json_reader = __commonJS({
     var assert_1 = require_assert();
     var reflection_long_convert_1 = require_reflection_long_convert();
     var ReflectionJsonReader = class {
-      constructor(info2) {
-        this.info = info2;
+      constructor(info3) {
+        this.info = info3;
       }
       prepare() {
         var _a;
@@ -24583,9 +24583,9 @@ var require_reflection_json_writer = __commonJS({
     var reflection_info_1 = require_reflection_info();
     var assert_1 = require_assert();
     var ReflectionJsonWriter = class {
-      constructor(info2) {
+      constructor(info3) {
         var _a;
-        this.fields = (_a = info2.fields) !== null && _a !== void 0 ? _a : [];
+        this.fields = (_a = info3.fields) !== null && _a !== void 0 ? _a : [];
       }
       /**
        * Converts the message to a JSON object, based on the field descriptors.
@@ -24838,8 +24838,8 @@ var require_reflection_binary_reader = __commonJS({
     var reflection_long_convert_1 = require_reflection_long_convert();
     var reflection_scalar_default_1 = require_reflection_scalar_default();
     var ReflectionBinaryReader = class {
-      constructor(info2) {
-        this.info = info2;
+      constructor(info3) {
+        this.info = info3;
       }
       prepare() {
         var _a;
@@ -25012,8 +25012,8 @@ var require_reflection_binary_writer = __commonJS({
     var assert_1 = require_assert();
     var pb_long_1 = require_pb_long();
     var ReflectionBinaryWriter = class {
-      constructor(info2) {
-        this.info = info2;
+      constructor(info3) {
+        this.info = info3;
       }
       prepare() {
         if (!this.fields) {
@@ -25263,9 +25263,9 @@ var require_reflection_merge_partial = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.reflectionMergePartial = void 0;
-    function reflectionMergePartial4(info2, target, source) {
+    function reflectionMergePartial4(info3, target, source) {
       let fieldValue, input = source, output;
-      for (let field of info2.fields) {
+      for (let field of info3.fields) {
         let name = field.localName;
         if (field.oneof) {
           const group = input[field.oneof];
@@ -25334,12 +25334,12 @@ var require_reflection_equals = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.reflectionEquals = void 0;
     var reflection_info_1 = require_reflection_info();
-    function reflectionEquals(info2, a, b) {
+    function reflectionEquals(info3, a, b) {
       if (a === b)
         return true;
       if (!a || !b)
         return false;
-      for (let field of info2.fields) {
+      for (let field of info3.fields) {
         let localName = field.localName;
         let val_a = field.oneof ? a[field.oneof][localName] : a[localName];
         let val_b = field.oneof ? b[field.oneof][localName] : b[localName];
@@ -27023,9 +27023,9 @@ var require_constants7 = __commonJS({
 var require_debug2 = __commonJS({
   "node_modules/@actions/tool-cache/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
-    var debug2 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
+    var debug3 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
-    module2.exports = debug2;
+    module2.exports = debug3;
   }
 });
 
@@ -27038,7 +27038,7 @@ var require_re2 = __commonJS({
       MAX_SAFE_BUILD_LENGTH,
       MAX_LENGTH
     } = require_constants7();
-    var debug2 = require_debug2();
+    var debug3 = require_debug2();
     exports2 = module2.exports = {};
     var re = exports2.re = [];
     var safeRe = exports2.safeRe = [];
@@ -27061,7 +27061,7 @@ var require_re2 = __commonJS({
     var createToken = (name, value, isGlobal) => {
       const safe = makeSafeRegex(value);
       const index = R++;
-      debug2(name, index, value);
+      debug3(name, index, value);
       t[name] = index;
       src[index] = value;
       safeSrc[index] = safe;
@@ -27165,7 +27165,7 @@ var require_identifiers2 = __commonJS({
 var require_semver3 = __commonJS({
   "node_modules/@actions/tool-cache/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
-    var debug2 = require_debug2();
+    var debug3 = require_debug2();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants7();
     var { safeRe: re, t } = require_re2();
     var parseOptions = require_parse_options2();
@@ -27187,7 +27187,7 @@ var require_semver3 = __commonJS({
             `version is longer than ${MAX_LENGTH} characters`
           );
         }
-        debug2("SemVer", version3, options);
+        debug3("SemVer", version3, options);
         this.options = options;
         this.loose = !!options.loose;
         this.includePrerelease = !!options.includePrerelease;
@@ -27235,7 +27235,7 @@ var require_semver3 = __commonJS({
         return this.version;
       }
       compare(other) {
-        debug2("SemVer.compare", this.version, this.options, other);
+        debug3("SemVer.compare", this.version, this.options, other);
         if (!(other instanceof _SemVer)) {
           if (typeof other === "string" && other === this.version) {
             return 0;
@@ -27286,7 +27286,7 @@ var require_semver3 = __commonJS({
         do {
           const a = this.prerelease[i];
           const b = other.prerelease[i];
-          debug2("prerelease compare", i, a, b);
+          debug3("prerelease compare", i, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -27308,7 +27308,7 @@ var require_semver3 = __commonJS({
         do {
           const a = this.build[i];
           const b = other.build[i];
-          debug2("build compare", i, a, b);
+          debug3("build compare", i, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -27936,21 +27936,21 @@ var require_range2 = __commonJS({
         const loose = this.options.loose;
         const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
         range2 = range2.replace(hr, hyphenReplace(this.options.includePrerelease));
-        debug2("hyphen replace", range2);
+        debug3("hyphen replace", range2);
         range2 = range2.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
-        debug2("comparator trim", range2);
+        debug3("comparator trim", range2);
         range2 = range2.replace(re[t.TILDETRIM], tildeTrimReplace);
-        debug2("tilde trim", range2);
+        debug3("tilde trim", range2);
         range2 = range2.replace(re[t.CARETTRIM], caretTrimReplace);
-        debug2("caret trim", range2);
+        debug3("caret trim", range2);
         let rangeList = range2.split(" ").map((comp26) => parseComparator(comp26, this.options)).join(" ").split(/\s+/).map((comp26) => replaceGTE0(comp26, this.options));
         if (loose) {
           rangeList = rangeList.filter((comp26) => {
-            debug2("loose invalid filter", comp26, this.options);
+            debug3("loose invalid filter", comp26, this.options);
             return !!comp26.match(re[t.COMPARATORLOOSE]);
           });
         }
-        debug2("range list", rangeList);
+        debug3("range list", rangeList);
         const rangeMap = /* @__PURE__ */ new Map();
         const comparators = rangeList.map((comp26) => new Comparator(comp26, this.options));
         for (const comp26 of comparators) {
@@ -28005,7 +28005,7 @@ var require_range2 = __commonJS({
     var cache = new LRU();
     var parseOptions = require_parse_options2();
     var Comparator = require_comparator2();
-    var debug2 = require_debug2();
+    var debug3 = require_debug2();
     var SemVer = require_semver3();
     var {
       safeRe: re,
@@ -28031,15 +28031,15 @@ var require_range2 = __commonJS({
     };
     var parseComparator = (comp26, options) => {
       comp26 = comp26.replace(re[t.BUILD], "");
-      debug2("comp", comp26, options);
+      debug3("comp", comp26, options);
       comp26 = replaceCarets(comp26, options);
-      debug2("caret", comp26);
+      debug3("caret", comp26);
       comp26 = replaceTildes(comp26, options);
-      debug2("tildes", comp26);
+      debug3("tildes", comp26);
       comp26 = replaceXRanges(comp26, options);
-      debug2("xrange", comp26);
+      debug3("xrange", comp26);
       comp26 = replaceStars(comp26, options);
-      debug2("stars", comp26);
+      debug3("stars", comp26);
       return comp26;
     };
     var isX = (id) => !id || id.toLowerCase() === "x" || id === "*";
@@ -28049,7 +28049,7 @@ var require_range2 = __commonJS({
     var replaceTilde = (comp26, options) => {
       const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
       return comp26.replace(r, (_, M, m, p, pr) => {
-        debug2("tilde", comp26, _, M, m, p, pr);
+        debug3("tilde", comp26, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
           ret = "";
@@ -28058,12 +28058,12 @@ var require_range2 = __commonJS({
         } else if (isX(p)) {
           ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
         } else if (pr) {
-          debug2("replaceTilde pr", pr);
+          debug3("replaceTilde pr", pr);
           ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
         } else {
           ret = `>=${M}.${m}.${p} <${M}.${+m + 1}.0-0`;
         }
-        debug2("tilde return", ret);
+        debug3("tilde return", ret);
         return ret;
       });
     };
@@ -28071,11 +28071,11 @@ var require_range2 = __commonJS({
       return comp26.trim().split(/\s+/).map((c) => replaceCaret(c, options)).join(" ");
     };
     var replaceCaret = (comp26, options) => {
-      debug2("caret", comp26, options);
+      debug3("caret", comp26, options);
       const r = options.loose ? re[t.CARETLOOSE] : re[t.CARET];
       const z = options.includePrerelease ? "-0" : "";
       return comp26.replace(r, (_, M, m, p, pr) => {
-        debug2("caret", comp26, _, M, m, p, pr);
+        debug3("caret", comp26, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
           ret = "";
@@ -28088,7 +28088,7 @@ var require_range2 = __commonJS({
             ret = `>=${M}.${m}.0${z} <${+M + 1}.0.0-0`;
           }
         } else if (pr) {
-          debug2("replaceCaret pr", pr);
+          debug3("replaceCaret pr", pr);
           if (M === "0") {
             if (m === "0") {
               ret = `>=${M}.${m}.${p}-${pr} <${M}.${m}.${+p + 1}-0`;
@@ -28099,7 +28099,7 @@ var require_range2 = __commonJS({
             ret = `>=${M}.${m}.${p}-${pr} <${+M + 1}.0.0-0`;
           }
         } else {
-          debug2("no pr");
+          debug3("no pr");
           if (M === "0") {
             if (m === "0") {
               ret = `>=${M}.${m}.${p}${z} <${M}.${m}.${+p + 1}-0`;
@@ -28110,19 +28110,19 @@ var require_range2 = __commonJS({
             ret = `>=${M}.${m}.${p} <${+M + 1}.0.0-0`;
           }
         }
-        debug2("caret return", ret);
+        debug3("caret return", ret);
         return ret;
       });
     };
     var replaceXRanges = (comp26, options) => {
-      debug2("replaceXRanges", comp26, options);
+      debug3("replaceXRanges", comp26, options);
       return comp26.split(/\s+/).map((c) => replaceXRange(c, options)).join(" ");
     };
     var replaceXRange = (comp26, options) => {
       comp26 = comp26.trim();
       const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
       return comp26.replace(r, (ret, gtlt, M, m, p, pr) => {
-        debug2("xRange", comp26, ret, gtlt, M, m, p, pr);
+        debug3("xRange", comp26, ret, gtlt, M, m, p, pr);
         const xM = isX(M);
         const xm = xM || isX(m);
         const xp = xm || isX(p);
@@ -28169,16 +28169,16 @@ var require_range2 = __commonJS({
         } else if (xp) {
           ret = `>=${M}.${m}.0${pr} <${M}.${+m + 1}.0-0`;
         }
-        debug2("xRange return", ret);
+        debug3("xRange return", ret);
         return ret;
       });
     };
     var replaceStars = (comp26, options) => {
-      debug2("replaceStars", comp26, options);
+      debug3("replaceStars", comp26, options);
       return comp26.trim().replace(re[t.STAR], "");
     };
     var replaceGTE0 = (comp26, options) => {
-      debug2("replaceGTE0", comp26, options);
+      debug3("replaceGTE0", comp26, options);
       return comp26.trim().replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], "");
     };
     var hyphenReplace = (incPr) => ($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr) => {
@@ -28216,7 +28216,7 @@ var require_range2 = __commonJS({
       }
       if (version3.prerelease.length && !options.includePrerelease) {
         for (let i = 0; i < set.length; i++) {
-          debug2(set[i].semver);
+          debug3(set[i].semver);
           if (set[i].semver === Comparator.ANY) {
             continue;
           }
@@ -28253,7 +28253,7 @@ var require_comparator2 = __commonJS({
           }
         }
         comp26 = comp26.trim().split(/\s+/).join(" ");
-        debug2("comparator", comp26, options);
+        debug3("comparator", comp26, options);
         this.options = options;
         this.loose = !!options.loose;
         this.parse(comp26);
@@ -28262,7 +28262,7 @@ var require_comparator2 = __commonJS({
         } else {
           this.value = this.operator + this.semver.version;
         }
-        debug2("comp", this);
+        debug3("comp", this);
       }
       parse(comp26) {
         const r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
@@ -28284,7 +28284,7 @@ var require_comparator2 = __commonJS({
         return this.value;
       }
       test(version3) {
-        debug2("Comparator.test", version3, this.options.loose);
+        debug3("Comparator.test", version3, this.options.loose);
         if (this.semver === ANY || version3 === ANY) {
           return true;
         }
@@ -28341,7 +28341,7 @@ var require_comparator2 = __commonJS({
     var parseOptions = require_parse_options2();
     var { safeRe: re, t } = require_re2();
     var cmp = require_cmp2();
-    var debug2 = require_debug2();
+    var debug3 = require_debug2();
     var SemVer = require_semver3();
     var Range = require_range2();
   }
@@ -38692,7 +38692,7 @@ var require_socks5_client = __commonJS({
     var { InvalidArgumentError, Socks5ProxyError } = require_errors2();
     var { debuglog } = require("node:util");
     var { parseAddress } = require_socks5_utils();
-    var debug2 = debuglog("undici:socks5");
+    var debug3 = debuglog("undici:socks5");
     var SOCKS_VERSION = 5;
     var AUTH_METHODS = {
       NO_AUTH: 0,
@@ -38753,7 +38753,7 @@ var require_socks5_client = __commonJS({
        * Handle incoming data from the socket
        */
       onData(data) {
-        debug2("received data", data.length, "bytes in state", this.state);
+        debug3("received data", data.length, "bytes in state", this.state);
         this.buffer = Buffer3.concat([this.buffer, data]);
         try {
           switch (this.state) {
@@ -38775,7 +38775,7 @@ var require_socks5_client = __commonJS({
        * Handle socket errors
        */
       onError(err) {
-        debug2("socket error", err);
+        debug3("socket error", err);
         this.state = STATES.ERROR;
         this.emit("error", err);
         this.destroy();
@@ -38784,7 +38784,7 @@ var require_socks5_client = __commonJS({
        * Handle socket close
        */
       onClose() {
-        debug2("socket closed");
+        debug3("socket closed");
         this.state = STATES.CLOSED;
         this.emit("close");
       }
@@ -38803,7 +38803,7 @@ var require_socks5_client = __commonJS({
         if (this.state !== STATES.INITIAL) {
           throw new InvalidArgumentError("Handshake already started");
         }
-        debug2("starting handshake with", this.authMethods.length, "auth methods");
+        debug3("starting handshake with", this.authMethods.length, "auth methods");
         this.state = STATES.HANDSHAKING;
         const request = Buffer3.alloc(2 + this.authMethods.length);
         request[0] = SOCKS_VERSION;
@@ -38829,7 +38829,7 @@ var require_socks5_client = __commonJS({
           throw new Socks5ProxyError("No acceptable authentication method", "UND_ERR_SOCKS5_AUTH_REJECTED");
         }
         this.buffer = this.buffer.subarray(2);
-        debug2("server selected auth method", method);
+        debug3("server selected auth method", method);
         if (method === AUTH_METHODS.NO_AUTH) {
           this.emit("authenticated");
         } else if (method === AUTH_METHODS.USERNAME_PASSWORD) {
@@ -38847,7 +38847,7 @@ var require_socks5_client = __commonJS({
         if (!username || !password) {
           throw new InvalidArgumentError("Username and password required for authentication");
         }
-        debug2("sending username/password auth");
+        debug3("sending username/password auth");
         const usernameBuffer = Buffer3.from(username);
         const passwordBuffer = Buffer3.from(password);
         if (usernameBuffer.length > 255 || passwordBuffer.length > 255) {
@@ -38877,7 +38877,7 @@ var require_socks5_client = __commonJS({
           throw new Socks5ProxyError("Authentication failed", "UND_ERR_SOCKS5_AUTH_FAILED");
         }
         this.buffer = this.buffer.subarray(2);
-        debug2("authentication successful");
+        debug3("authentication successful");
         this.emit("authenticated");
       }
       /**
@@ -38889,7 +38889,7 @@ var require_socks5_client = __commonJS({
         if (this.state === STATES.CONNECTED) {
           throw new InvalidArgumentError("Already connected");
         }
-        debug2("connecting to", address, port);
+        debug3("connecting to", address, port);
         this.state = STATES.CONNECTING;
         const request = this.buildConnectRequest(COMMANDS.CONNECT, address, port);
         this.socket.write(request);
@@ -38963,7 +38963,7 @@ var require_socks5_client = __commonJS({
         const boundPort = this.buffer.readUInt16BE(offset);
         this.buffer = this.buffer.subarray(responseLength);
         this.state = STATES.CONNECTED;
-        debug2("connected, bound address:", boundAddress, "port:", boundPort);
+        debug3("connected, bound address:", boundAddress, "port:", boundPort);
         this.emit("connected", { address: boundAddress, port: boundPort });
       }
       /**
@@ -39017,7 +39017,7 @@ var require_socks5_proxy_agent = __commonJS({
     var Pool = require_pool2();
     var buildConnector = require_connect2();
     var { debuglog } = require("node:util");
-    var debug2 = debuglog("undici:socks5-proxy");
+    var debug3 = debuglog("undici:socks5-proxy");
     var kProxyUrl = /* @__PURE__ */ Symbol("proxy url");
     var kProxyHeaders = /* @__PURE__ */ Symbol("proxy headers");
     var kProxyAuth = /* @__PURE__ */ Symbol("proxy auth");
@@ -39059,7 +39059,7 @@ var require_socks5_proxy_agent = __commonJS({
       async createSocks5Connection(targetHost, targetPort) {
         const proxyHost = this[kProxyUrl].hostname;
         const proxyPort = parseInt(this[kProxyUrl].port) || 1080;
-        debug2("creating SOCKS5 connection to", proxyHost, proxyPort);
+        debug3("creating SOCKS5 connection to", proxyHost, proxyPort);
         const socket = await new Promise((resolve3, reject) => {
           const onConnect = () => {
             socket2.removeListener("error", onError);
@@ -39078,7 +39078,7 @@ var require_socks5_proxy_agent = __commonJS({
         });
         const socks5Client = new Socks5Client(socket, this[kProxyAuth]);
         socks5Client.on("error", (err) => {
-          debug2("SOCKS5 error:", err);
+          debug3("SOCKS5 error:", err);
           socket.destroy();
         });
         await socks5Client.handshake();
@@ -39109,8 +39109,8 @@ var require_socks5_proxy_agent = __commonJS({
           const timeout = setTimeout(() => {
             reject(new Error("SOCKS5 connection timeout"));
           }, 5e3);
-          const onConnected = (info2) => {
-            debug2("SOCKS5 tunnel established to", targetHost, targetPort, "via", info2);
+          const onConnected = (info3) => {
+            debug3("SOCKS5 tunnel established to", targetHost, targetPort, "via", info3);
             clearTimeout(timeout);
             socks5Client.removeListener("error", onError);
             resolve3();
@@ -39130,7 +39130,7 @@ var require_socks5_proxy_agent = __commonJS({
        */
       async [kDispatch](opts, handler) {
         const { origin } = opts;
-        debug2("dispatching request to", origin, "via SOCKS5");
+        debug3("dispatching request to", origin, "via SOCKS5");
         try {
           if (!this[kPool] || this[kPool].destroyed || this[kPool].closed) {
             this[kPool] = new Pool(origin, {
@@ -39141,14 +39141,14 @@ var require_socks5_proxy_agent = __commonJS({
                   const url2 = new URL3(origin);
                   const targetHost = url2.hostname;
                   const targetPort = parseInt(url2.port) || (url2.protocol === "https:" ? 443 : 80);
-                  debug2("establishing SOCKS5 connection to", targetHost, targetPort);
+                  debug3("establishing SOCKS5 connection to", targetHost, targetPort);
                   const socket = await this.createSocks5Connection(targetHost, targetPort);
                   let finalSocket = socket;
                   if (url2.protocol === "https:") {
                     if (!tls) {
                       tls = require("node:tls");
                     }
-                    debug2("upgrading to TLS");
+                    debug3("upgrading to TLS");
                     finalSocket = tls.connect({
                       socket,
                       servername: targetHost,
@@ -39161,7 +39161,7 @@ var require_socks5_proxy_agent = __commonJS({
                   }
                   callback(null, finalSocket);
                 } catch (err) {
-                  debug2("SOCKS5 connection error:", err);
+                  debug3("SOCKS5 connection error:", err);
                   callback(err);
                 }
               }
@@ -39169,7 +39169,7 @@ var require_socks5_proxy_agent = __commonJS({
           }
           return this[kPool][kDispatch](opts, handler);
         } catch (err) {
-          debug2("dispatch error:", err);
+          debug3("dispatch error:", err);
           if (typeof handler.onError === "function") {
             handler.onError(err);
           } else {
@@ -54309,15 +54309,15 @@ var require_pep440 = __commonJS({
 var require_semver5 = __commonJS({
   "node_modules/semver/semver.js"(exports2, module2) {
     exports2 = module2.exports = SemVer;
-    var debug2;
+    var debug3;
     if (typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG)) {
-      debug2 = function() {
+      debug3 = function() {
         var args = Array.prototype.slice.call(arguments, 0);
         args.unshift("SEMVER");
         console.log.apply(console, args);
       };
     } else {
-      debug2 = function() {
+      debug3 = function() {
       };
     }
     exports2.SEMVER_SPEC_VERSION = "2.0.0";
@@ -54435,7 +54435,7 @@ var require_semver5 = __commonJS({
     tok("STAR");
     src[t.STAR] = "(<|>)?=?\\s*\\*";
     for (i = 0; i < R; i++) {
-      debug2(i, src[i]);
+      debug3(i, src[i]);
       if (!re[i]) {
         re[i] = new RegExp(src[i]);
         safeRe[i] = new RegExp(makeSafeRe(src[i]));
@@ -54502,7 +54502,7 @@ var require_semver5 = __commonJS({
       if (!(this instanceof SemVer)) {
         return new SemVer(version3, options);
       }
-      debug2("SemVer", version3, options);
+      debug3("SemVer", version3, options);
       this.options = options;
       this.loose = !!options.loose;
       var m = version3.trim().match(options.loose ? safeRe[t.LOOSE] : safeRe[t.FULL]);
@@ -54549,7 +54549,7 @@ var require_semver5 = __commonJS({
       return this.version;
     };
     SemVer.prototype.compare = function(other) {
-      debug2("SemVer.compare", this.version, this.options, other);
+      debug3("SemVer.compare", this.version, this.options, other);
       if (!(other instanceof SemVer)) {
         other = new SemVer(other, this.options);
       }
@@ -54576,7 +54576,7 @@ var require_semver5 = __commonJS({
       do {
         var a = this.prerelease[i2];
         var b = other.prerelease[i2];
-        debug2("prerelease compare", i2, a, b);
+        debug3("prerelease compare", i2, a, b);
         if (a === void 0 && b === void 0) {
           return 0;
         } else if (b === void 0) {
@@ -54598,7 +54598,7 @@ var require_semver5 = __commonJS({
       do {
         var a = this.build[i2];
         var b = other.build[i2];
-        debug2("prerelease compare", i2, a, b);
+        debug3("prerelease compare", i2, a, b);
         if (a === void 0 && b === void 0) {
           return 0;
         } else if (b === void 0) {
@@ -54862,7 +54862,7 @@ var require_semver5 = __commonJS({
         return new Comparator(comp26, options);
       }
       comp26 = comp26.trim().split(/\s+/).join(" ");
-      debug2("comparator", comp26, options);
+      debug3("comparator", comp26, options);
       this.options = options;
       this.loose = !!options.loose;
       this.parse(comp26);
@@ -54871,7 +54871,7 @@ var require_semver5 = __commonJS({
       } else {
         this.value = this.operator + this.semver.version;
       }
-      debug2("comp", this);
+      debug3("comp", this);
     }
     var ANY = {};
     Comparator.prototype.parse = function(comp26) {
@@ -54894,7 +54894,7 @@ var require_semver5 = __commonJS({
       return this.value;
     };
     Comparator.prototype.test = function(version3) {
-      debug2("Comparator.test", version3, this.options.loose);
+      debug3("Comparator.test", version3, this.options.loose);
       if (this.semver === ANY || version3 === ANY) {
         return true;
       }
@@ -54987,9 +54987,9 @@ var require_semver5 = __commonJS({
       var loose = this.options.loose;
       var hr = loose ? safeRe[t.HYPHENRANGELOOSE] : safeRe[t.HYPHENRANGE];
       range2 = range2.replace(hr, hyphenReplace);
-      debug2("hyphen replace", range2);
+      debug3("hyphen replace", range2);
       range2 = range2.replace(safeRe[t.COMPARATORTRIM], comparatorTrimReplace);
-      debug2("comparator trim", range2, safeRe[t.COMPARATORTRIM]);
+      debug3("comparator trim", range2, safeRe[t.COMPARATORTRIM]);
       range2 = range2.replace(safeRe[t.TILDETRIM], tildeTrimReplace);
       range2 = range2.replace(safeRe[t.CARETTRIM], caretTrimReplace);
       range2 = range2.split(/\s+/).join(" ");
@@ -55042,15 +55042,15 @@ var require_semver5 = __commonJS({
       });
     }
     function parseComparator(comp26, options) {
-      debug2("comp", comp26, options);
+      debug3("comp", comp26, options);
       comp26 = replaceCarets(comp26, options);
-      debug2("caret", comp26);
+      debug3("caret", comp26);
       comp26 = replaceTildes(comp26, options);
-      debug2("tildes", comp26);
+      debug3("tildes", comp26);
       comp26 = replaceXRanges(comp26, options);
-      debug2("xrange", comp26);
+      debug3("xrange", comp26);
       comp26 = replaceStars(comp26, options);
-      debug2("stars", comp26);
+      debug3("stars", comp26);
       return comp26;
     }
     function isX(id) {
@@ -55064,7 +55064,7 @@ var require_semver5 = __commonJS({
     function replaceTilde(comp26, options) {
       var r = options.loose ? safeRe[t.TILDELOOSE] : safeRe[t.TILDE];
       return comp26.replace(r, function(_, M, m, p, pr) {
-        debug2("tilde", comp26, _, M, m, p, pr);
+        debug3("tilde", comp26, _, M, m, p, pr);
         var ret;
         if (isX(M)) {
           ret = "";
@@ -55073,12 +55073,12 @@ var require_semver5 = __commonJS({
         } else if (isX(p)) {
           ret = ">=" + M + "." + m + ".0 <" + M + "." + (+m + 1) + ".0";
         } else if (pr) {
-          debug2("replaceTilde pr", pr);
+          debug3("replaceTilde pr", pr);
           ret = ">=" + M + "." + m + "." + p + "-" + pr + " <" + M + "." + (+m + 1) + ".0";
         } else {
           ret = ">=" + M + "." + m + "." + p + " <" + M + "." + (+m + 1) + ".0";
         }
-        debug2("tilde return", ret);
+        debug3("tilde return", ret);
         return ret;
       });
     }
@@ -55088,10 +55088,10 @@ var require_semver5 = __commonJS({
       }).join(" ");
     }
     function replaceCaret(comp26, options) {
-      debug2("caret", comp26, options);
+      debug3("caret", comp26, options);
       var r = options.loose ? safeRe[t.CARETLOOSE] : safeRe[t.CARET];
       return comp26.replace(r, function(_, M, m, p, pr) {
-        debug2("caret", comp26, _, M, m, p, pr);
+        debug3("caret", comp26, _, M, m, p, pr);
         var ret;
         if (isX(M)) {
           ret = "";
@@ -55104,7 +55104,7 @@ var require_semver5 = __commonJS({
             ret = ">=" + M + "." + m + ".0 <" + (+M + 1) + ".0.0";
           }
         } else if (pr) {
-          debug2("replaceCaret pr", pr);
+          debug3("replaceCaret pr", pr);
           if (M === "0") {
             if (m === "0") {
               ret = ">=" + M + "." + m + "." + p + "-" + pr + " <" + M + "." + m + "." + (+p + 1);
@@ -55115,7 +55115,7 @@ var require_semver5 = __commonJS({
             ret = ">=" + M + "." + m + "." + p + "-" + pr + " <" + (+M + 1) + ".0.0";
           }
         } else {
-          debug2("no pr");
+          debug3("no pr");
           if (M === "0") {
             if (m === "0") {
               ret = ">=" + M + "." + m + "." + p + " <" + M + "." + m + "." + (+p + 1);
@@ -55126,12 +55126,12 @@ var require_semver5 = __commonJS({
             ret = ">=" + M + "." + m + "." + p + " <" + (+M + 1) + ".0.0";
           }
         }
-        debug2("caret return", ret);
+        debug3("caret return", ret);
         return ret;
       });
     }
     function replaceXRanges(comp26, options) {
-      debug2("replaceXRanges", comp26, options);
+      debug3("replaceXRanges", comp26, options);
       return comp26.split(/\s+/).map(function(comp27) {
         return replaceXRange(comp27, options);
       }).join(" ");
@@ -55140,7 +55140,7 @@ var require_semver5 = __commonJS({
       comp26 = comp26.trim();
       var r = options.loose ? safeRe[t.XRANGELOOSE] : safeRe[t.XRANGE];
       return comp26.replace(r, function(ret, gtlt, M, m, p, pr) {
-        debug2("xRange", comp26, ret, gtlt, M, m, p, pr);
+        debug3("xRange", comp26, ret, gtlt, M, m, p, pr);
         var xM = isX(M);
         var xm = xM || isX(m);
         var xp = xm || isX(p);
@@ -55184,12 +55184,12 @@ var require_semver5 = __commonJS({
         } else if (xp) {
           ret = ">=" + M + "." + m + ".0" + pr + " <" + M + "." + (+m + 1) + ".0" + pr;
         }
-        debug2("xRange return", ret);
+        debug3("xRange return", ret);
         return ret;
       });
     }
     function replaceStars(comp26, options) {
-      debug2("replaceStars", comp26, options);
+      debug3("replaceStars", comp26, options);
       return comp26.trim().replace(safeRe[t.STAR], "");
     }
     function hyphenReplace($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr, tb) {
@@ -55241,7 +55241,7 @@ var require_semver5 = __commonJS({
       }
       if (version3.prerelease.length && !options.includePrerelease) {
         for (i2 = 0; i2 < set.length; i2++) {
-          debug2(set[i2].semver);
+          debug3(set[i2].semver);
           if (set[i2].semver === ANY) {
             continue;
           }
@@ -55895,12 +55895,12 @@ var HttpClient = class {
         throw new Error("Client has already been disposed.");
       }
       const parsedUrl = new URL(requestUrl);
-      let info2 = this._prepareRequest(verb, parsedUrl, headers);
+      let info3 = this._prepareRequest(verb, parsedUrl, headers);
       const maxTries = this._allowRetries && RetryableHttpVerbs.includes(verb) ? this._maxRetries + 1 : 1;
       let numTries = 0;
       let response;
       do {
-        response = yield this.requestRaw(info2, data);
+        response = yield this.requestRaw(info3, data);
         if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
           let authenticationHandler;
           for (const handler of this.handlers) {
@@ -55910,7 +55910,7 @@ var HttpClient = class {
             }
           }
           if (authenticationHandler) {
-            return authenticationHandler.handleAuthentication(this, info2, data);
+            return authenticationHandler.handleAuthentication(this, info3, data);
           } else {
             return response;
           }
@@ -55933,8 +55933,8 @@ var HttpClient = class {
               }
             }
           }
-          info2 = this._prepareRequest(verb, parsedRedirectUrl, headers);
-          response = yield this.requestRaw(info2, data);
+          info3 = this._prepareRequest(verb, parsedRedirectUrl, headers);
+          response = yield this.requestRaw(info3, data);
           redirectsRemaining--;
         }
         if (!response.message.statusCode || !HttpResponseRetryCodes.includes(response.message.statusCode)) {
@@ -55963,7 +55963,7 @@ var HttpClient = class {
    * @param info
    * @param data
    */
-  requestRaw(info2, data) {
+  requestRaw(info3, data) {
     return __awaiter(this, void 0, void 0, function* () {
       return new Promise((resolve3, reject) => {
         function callbackForResult(err, res) {
@@ -55975,7 +55975,7 @@ var HttpClient = class {
             resolve3(res);
           }
         }
-        this.requestRawWithCallback(info2, data, callbackForResult);
+        this.requestRawWithCallback(info3, data, callbackForResult);
       });
     });
   }
@@ -55985,12 +55985,12 @@ var HttpClient = class {
    * @param data
    * @param onResult
    */
-  requestRawWithCallback(info2, data, onResult) {
+  requestRawWithCallback(info3, data, onResult) {
     if (typeof data === "string") {
-      if (!info2.options.headers) {
-        info2.options.headers = {};
+      if (!info3.options.headers) {
+        info3.options.headers = {};
       }
-      info2.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
+      info3.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
     }
     let callbackCalled = false;
     function handleResult(err, res) {
@@ -55999,7 +55999,7 @@ var HttpClient = class {
         onResult(err, res);
       }
     }
-    const req = info2.httpModule.request(info2.options, (msg) => {
+    const req = info3.httpModule.request(info3.options, (msg) => {
       const res = new HttpClientResponse(msg);
       handleResult(void 0, res);
     });
@@ -56011,7 +56011,7 @@ var HttpClient = class {
       if (socket) {
         socket.end();
       }
-      handleResult(new Error(`Request timeout: ${info2.options.path}`));
+      handleResult(new Error(`Request timeout: ${info3.options.path}`));
     });
     req.on("error", function(err) {
       handleResult(err);
@@ -56047,27 +56047,27 @@ var HttpClient = class {
     return this._getProxyAgentDispatcher(parsedUrl, proxyUrl);
   }
   _prepareRequest(method, requestUrl, headers) {
-    const info2 = {};
-    info2.parsedUrl = requestUrl;
-    const usingSsl = info2.parsedUrl.protocol === "https:";
-    info2.httpModule = usingSsl ? https : http;
+    const info3 = {};
+    info3.parsedUrl = requestUrl;
+    const usingSsl = info3.parsedUrl.protocol === "https:";
+    info3.httpModule = usingSsl ? https : http;
     const defaultPort = usingSsl ? 443 : 80;
-    info2.options = {};
-    info2.options.host = info2.parsedUrl.hostname;
-    info2.options.port = info2.parsedUrl.port ? parseInt(info2.parsedUrl.port) : defaultPort;
-    info2.options.path = (info2.parsedUrl.pathname || "") + (info2.parsedUrl.search || "");
-    info2.options.method = method;
-    info2.options.headers = this._mergeHeaders(headers);
+    info3.options = {};
+    info3.options.host = info3.parsedUrl.hostname;
+    info3.options.port = info3.parsedUrl.port ? parseInt(info3.parsedUrl.port) : defaultPort;
+    info3.options.path = (info3.parsedUrl.pathname || "") + (info3.parsedUrl.search || "");
+    info3.options.method = method;
+    info3.options.headers = this._mergeHeaders(headers);
     if (this.userAgent != null) {
-      info2.options.headers["user-agent"] = this.userAgent;
+      info3.options.headers["user-agent"] = this.userAgent;
     }
-    info2.options.agent = this._getAgent(info2.parsedUrl);
+    info3.options.agent = this._getAgent(info3.parsedUrl);
     if (this.handlers) {
       for (const handler of this.handlers) {
-        handler.prepareRequest(info2.options);
+        handler.prepareRequest(info3.options);
       }
     }
-    return info2;
+    return info3;
   }
   _mergeHeaders(headers) {
     if (this.requestOptions && this.requestOptions.headers) {
@@ -58522,14 +58522,14 @@ function disable() {
   return result;
 }
 function createDebugger(namespace) {
-  const newDebugger = Object.assign(debug2, {
+  const newDebugger = Object.assign(debug3, {
     enabled: enabled(namespace),
     destroy,
     log: debugObj.log,
     namespace,
     extend
   });
-  function debug2(...args) {
+  function debug3(...args) {
     if (!newDebugger.enabled) {
       return;
     }
@@ -62019,12 +62019,12 @@ function getOperationRequestInfo(request) {
   if (hasOriginalRequest(request)) {
     return getOperationRequestInfo(request[originalRequestSymbol]);
   }
-  let info2 = state2.operationRequestMap.get(request);
-  if (!info2) {
-    info2 = {};
-    state2.operationRequestMap.set(request, info2);
+  let info3 = state2.operationRequestMap.get(request);
+  if (!info3) {
+    info3 = {};
+    state2.operationRequestMap.set(request, info3);
   }
-  return info2;
+  return info3;
 }
 
 // node_modules/@azure/core-client/dist/esm/deserializationPolicy.js
@@ -90289,10 +90289,28 @@ var crypto4 = __toESM(require("node:crypto"), 1);
 var fs7 = __toESM(require("node:fs"), 1);
 var stream2 = __toESM(require("node:stream"), 1);
 var util5 = __toESM(require("node:util"), 1);
+
+// src/utils/logging.ts
+var quiet;
+function isQuiet() {
+  if (quiet === void 0) {
+    quiet = typeof getInput === "function" && getInput("quiet") === "true";
+  }
+  return quiet;
+}
+function info2(msg) {
+  if (!isQuiet()) {
+    info(msg);
+  }
+}
+var warning2 = warning;
+var debug2 = debug;
+
+// src/hash/hash-files.ts
 async function hashFiles2(pattern, verbose = false) {
   const globber = await create(pattern);
   let hasMatch = false;
-  const writeDelegate = verbose ? info : debug;
+  const writeDelegate = verbose ? info2 : debug2;
   const result = crypto4.createHash("sha256");
   let count = 0;
   for await (const file of globber.globGenerator()) {
@@ -90445,7 +90463,7 @@ async function restoreCache2(inputs, pythonVersion) {
   saveState(STATE_CACHE_KEY, cacheKey);
   setOutput("cache-key", cacheKey);
   if (!inputs.restoreCache) {
-    info("restore-cache is false. Skipping restore cache step.");
+    info2("restore-cache is false. Skipping restore cache step.");
     setOutput("python-cache-hit", false);
     return;
   }
@@ -90472,7 +90490,7 @@ async function restoreCache2(inputs, pythonVersion) {
   }
 }
 async function restoreCacheFromKey(cacheKey, cachePath, stateKey, outputKey) {
-  info(
+  info2(
     `Trying to restore cache from GitHub Actions cache with key: ${cacheKey}`
   );
   let matchedKey;
@@ -90480,7 +90498,7 @@ async function restoreCacheFromKey(cacheKey, cachePath, stateKey, outputKey) {
     matchedKey = await restoreCache([cachePath], cacheKey);
   } catch (err) {
     const message = err.message;
-    warning(message);
+    warning2(message);
     setOutput(outputKey, false);
     return;
   }
@@ -90489,7 +90507,7 @@ async function restoreCacheFromKey(cacheKey, cachePath, stateKey, outputKey) {
 async function computeKeys(inputs, pythonVersion) {
   let cacheDependencyPathHash = "-";
   if (inputs.cacheDependencyGlob !== "") {
-    info(
+    info2(
       `Searching files using cache dependency glob: ${inputs.cacheDependencyGlob.split("\n").join(",")}`
     );
     cacheDependencyPathHash += await hashFiles2(
@@ -90497,7 +90515,7 @@ async function computeKeys(inputs, pythonVersion) {
       true
     );
     if (cacheDependencyPathHash === "-") {
-      warning(
+      warning2(
         `No file matched to [${inputs.cacheDependencyGlob.split("\n").join(",")}]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.`
       );
     }
@@ -90515,12 +90533,12 @@ async function computeKeys(inputs, pythonVersion) {
 }
 function handleMatchResult(matchedKey, primaryKey, stateKey, outputKey) {
   if (!matchedKey) {
-    info(`No GitHub Actions cache found for key: ${primaryKey}`);
+    info2(`No GitHub Actions cache found for key: ${primaryKey}`);
     setOutput(outputKey, false);
     return;
   }
   saveState(stateKey, matchedKey);
-  info(`cache restored from GitHub Actions cache with key: ${matchedKey}`);
+  info2(`cache restored from GitHub Actions cache with key: ${matchedKey}`);
   setOutput(outputKey, true);
 }
 
@@ -95835,7 +95853,7 @@ async function fetchManifest(manifestUrl = VERSIONS_MANIFEST_URL) {
     debug(`Using cached manifest data from ${manifestUrl}`);
     return cachedVersions;
   }
-  info(`Fetching manifest data from ${manifestUrl} ...`);
+  info2(`Fetching manifest data from ${manifestUrl} ...`);
   const response = await fetch(manifestUrl, {});
   if (!response.ok) {
     throw new Error(
@@ -95892,7 +95910,7 @@ async function getLatestVersion(manifestUrl = VERSIONS_MANIFEST_URL) {
   return latestVersion;
 }
 async function getAllVersions(manifestUrl = VERSIONS_MANIFEST_URL) {
-  info(
+  info2(
     `Getting available versions from ${manifestSource(manifestUrl)} ...`
   );
   const versions = await fetchManifest(manifestUrl);
@@ -96796,9 +96814,9 @@ var VERSION_FILE_PARSERS = [
   }
 ];
 function getParsedVersionFile(filePath) {
-  info(`Trying to find version for uv in: ${filePath}`);
+  info2(`Trying to find version for uv in: ${filePath}`);
   if (!import_node_fs5.default.existsSync(filePath)) {
-    info(`Could not find file: ${filePath}`);
+    info2(`Could not find file: ${filePath}`);
     return void 0;
   }
   const parser = getVersionFileParser(filePath);
@@ -96811,15 +96829,13 @@ function getParsedVersionFile(filePath) {
       return void 0;
     }
     const normalizedSpecifier = normalizeVersionSpecifier(specifier);
-    info(`Found version for uv in ${filePath}: ${normalizedSpecifier}`);
+    info2(`Found version for uv in ${filePath}: ${normalizedSpecifier}`);
     return {
       format: parser.format,
       specifier: normalizedSpecifier
     };
   } catch (error2) {
-    warning(
-      `Error while parsing ${filePath}: ${error2.message}`
-    );
+    warning2(`Error while parsing ${filePath}: ${error2.message}`);
     return void 0;
   }
 }
@@ -96904,7 +96920,7 @@ var WorkspaceVersionResolver = class {
         specifier: versionFile.specifier
       };
     }
-    info(
+    info2(
       "Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest."
     );
     return void 0;
@@ -96961,7 +96977,7 @@ var LatestVersionResolver2 = class {
       return void 0;
     }
     if (context3.parsedSpecifier.kind === "range" && context3.parsedSpecifier.isSimpleMinimumVersionSpecifier) {
-      info("Found minimum version specifier, using latest version");
+      info2("Found minimum version specifier, using latest version");
     }
     const latestVersion = await getLatestVersion(context3.manifestUrl);
     if (context3.parsedSpecifier.kind === "range" && context3.parsedSpecifier.isSimpleMinimumVersionSpecifier && !pep440.satisfies(latestVersion, context3.parsedSpecifier.raw)) {
@@ -97081,7 +97097,7 @@ async function downloadVersion(platform2, arch3, version3, checksum, githubToken
     if (mirrorUrl === void 0) {
       throw err;
     }
-    warning(
+    warning2(
       `Failed to download from mirror, falling back to GitHub Releases: ${err.message}`
     );
     return await downloadArtifact(
@@ -97109,7 +97125,7 @@ function githubTokenForUrl(downloadUrl, githubToken) {
   }
 }
 async function downloadArtifact(downloadUrl, artifactName, platform2, arch3, version3, checksum, githubToken) {
-  info(`Downloading uv from "${downloadUrl}" ...`);
+  info2(`Downloading uv from "${downloadUrl}" ...`);
   const downloadPath = await downloadTool(
     downloadUrl,
     void 0,
@@ -97121,7 +97137,7 @@ async function downloadArtifact(downloadUrl, artifactName, platform2, arch3, ver
     try {
       uvDir = await extractTar2(downloadPath, void 0, "x");
     } catch (err) {
-      info(
+      info2(
         `Extracting with tar failed, falling back to zip extraction: ${err.message}`
       );
       const extension = getExtension(platform2);
@@ -97186,6 +97202,7 @@ function loadInputs() {
   const manifestFile = getManifestFile();
   const downloadFromAstralMirror = getInput("download-from-astral-mirror") === "true";
   const addProblemMatchers = getInput("add-problem-matchers") === "true";
+  const quiet2 = getInput("quiet") === "true";
   const resolutionStrategy = getResolutionStrategy();
   return {
     activateEnvironment: activateEnvironment2,
@@ -97205,6 +97222,7 @@ function loadInputs() {
     pruneCache,
     pythonDir,
     pythonVersion,
+    quiet: quiet2,
     resolutionStrategy,
     restoreCache: restoreCache3,
     saveCache: saveCache2,
@@ -97228,7 +97246,7 @@ function getVenvPath(workingDirectory, activateEnvironment2) {
   const venvPathInput = getInput("venv-path");
   if (venvPathInput !== "") {
     if (!activateEnvironment2) {
-      warning("venv-path is only used when activate-environment is true");
+      warning2("venv-path is only used when activate-environment is true");
     }
     const tildeExpanded = expandTilde(venvPathInput);
     return normalizePath(resolveRelativePath(workingDirectory, tildeExpanded));
@@ -97291,7 +97309,7 @@ function getCacheLocalPath(workingDirectory, versionFile, enableCache) {
     return { path: cacheDirFromConfig, source: 1 /* Config */ };
   }
   if (process.env.UV_CACHE_DIR !== void 0) {
-    info(`UV_CACHE_DIR is already set to ${process.env.UV_CACHE_DIR}`);
+    info2(`UV_CACHE_DIR is already set to ${process.env.UV_CACHE_DIR}`);
     return { path: process.env.UV_CACHE_DIR, source: 2 /* Env */ };
   }
   if (enableCache) {
@@ -97324,12 +97342,12 @@ function getCacheDirFromConfig(workingDirectory, versionFile) {
     try {
       const cacheDir2 = getConfigValueFromTomlFile(resolvedPath, "cache-dir");
       if (cacheDir2 !== void 0) {
-        info(`Found cache-dir in ${resolvedPath}: ${cacheDir2}`);
+        info2(`Found cache-dir in ${resolvedPath}: ${cacheDir2}`);
         return cacheDir2;
       }
     } catch (err) {
       const message = err.message;
-      warning(`Error while parsing ${filePath}: ${message}`);
+      warning2(`Error while parsing ${filePath}: ${message}`);
       return void 0;
     }
   }
@@ -97337,7 +97355,7 @@ function getCacheDirFromConfig(workingDirectory, versionFile) {
 }
 function getUvPythonDir() {
   if (process.env.UV_PYTHON_INSTALL_DIR !== void 0) {
-    info(
+    info2(
       `UV_PYTHON_INSTALL_DIR is already set to ${process.env.UV_PYTHON_INSTALL_DIR}`
     );
     return process.env.UV_PYTHON_INSTALL_DIR;
@@ -97473,7 +97491,7 @@ async function run() {
     setCacheDir(inputs);
     setOutput("uv-version", setupResult.version);
     saveState(STATE_UV_VERSION, setupResult.version);
-    info(`Successfully installed uv version ${setupResult.version}`);
+    info2(`Successfully installed uv version ${setupResult.version}`);
     const detectedPythonVersion = await getPythonVersion(inputs);
     setOutput("python-version", detectedPythonVersion);
     if (inputs.enableCache) {
@@ -97488,11 +97506,11 @@ async function run() {
 function detectEmptyWorkdir(inputs) {
   if (import_node_fs7.default.readdirSync(inputs.workingDirectory).length === 0) {
     if (inputs.ignoreEmptyWorkdir) {
-      info(
+      info2(
         "Empty workdir detected. Ignoring because ignore-empty-workdir is enabled"
       );
     } else {
-      warning(
+      warning2(
         "Empty workdir detected. This may cause unexpected behavior. You can enable ignore-empty-workdir to mute this warning."
       );
     }
@@ -97508,7 +97526,7 @@ async function setupUv(inputs, platform2, arch3) {
   });
   const toolCacheResult = tryGetFromToolCache(arch3, resolvedVersion);
   if (toolCacheResult.installedPath) {
-    info(`Found uv in tool-cache for ${toolCacheResult.version}`);
+    info2(`Found uv in tool-cache for ${toolCacheResult.version}`);
     return {
       uvDir: toolCacheResult.installedPath,
       version: toolCacheResult.version
@@ -97533,61 +97551,61 @@ function addUvToPathAndOutput(cachedPath) {
   saveState(STATE_UV_PATH, `${cachedPath}${path16.sep}uv`);
   setOutput("uvx-path", `${cachedPath}${path16.sep}uvx`);
   if (process.env.UV_NO_MODIFY_PATH !== void 0) {
-    info("UV_NO_MODIFY_PATH is set, not modifying PATH");
+    info2("UV_NO_MODIFY_PATH is set, not modifying PATH");
   } else {
     addPath(cachedPath);
-    info(`Added ${cachedPath} to the path`);
+    info2(`Added ${cachedPath} to the path`);
   }
 }
 function addToolBinToPath(inputs) {
   if (inputs.toolBinDir !== void 0) {
     exportVariable("UV_TOOL_BIN_DIR", inputs.toolBinDir);
-    info(`Set UV_TOOL_BIN_DIR to ${inputs.toolBinDir}`);
+    info2(`Set UV_TOOL_BIN_DIR to ${inputs.toolBinDir}`);
     if (process.env.UV_NO_MODIFY_PATH !== void 0) {
-      info(
+      info2(
         `UV_NO_MODIFY_PATH is set, not adding ${inputs.toolBinDir} to path`
       );
     } else {
       addPath(inputs.toolBinDir);
-      info(`Added ${inputs.toolBinDir} to the path`);
+      info2(`Added ${inputs.toolBinDir} to the path`);
     }
   } else {
     if (process.env.UV_NO_MODIFY_PATH !== void 0) {
-      info("UV_NO_MODIFY_PATH is set, not adding user local bin to path");
+      info2("UV_NO_MODIFY_PATH is set, not adding user local bin to path");
       return;
     }
     if (process.env.XDG_BIN_HOME !== void 0) {
       addPath(process.env.XDG_BIN_HOME);
-      info(`Added ${process.env.XDG_BIN_HOME} to the path`);
+      info2(`Added ${process.env.XDG_BIN_HOME} to the path`);
     } else if (process.env.XDG_DATA_HOME !== void 0) {
       addPath(`${process.env.XDG_DATA_HOME}/../bin`);
-      info(`Added ${process.env.XDG_DATA_HOME}/../bin to the path`);
+      info2(`Added ${process.env.XDG_DATA_HOME}/../bin to the path`);
     } else {
       addPath(`${process.env.HOME}/.local/bin`);
-      info(`Added ${process.env.HOME}/.local/bin to the path`);
+      info2(`Added ${process.env.HOME}/.local/bin to the path`);
     }
   }
 }
 function setToolDir(inputs) {
   if (inputs.toolDir !== void 0) {
     exportVariable("UV_TOOL_DIR", inputs.toolDir);
-    info(`Set UV_TOOL_DIR to ${inputs.toolDir}`);
+    info2(`Set UV_TOOL_DIR to ${inputs.toolDir}`);
   }
 }
 function addPythonDirToPath(inputs) {
   exportVariable("UV_PYTHON_INSTALL_DIR", inputs.pythonDir);
-  info(`Set UV_PYTHON_INSTALL_DIR to ${inputs.pythonDir}`);
+  info2(`Set UV_PYTHON_INSTALL_DIR to ${inputs.pythonDir}`);
   if (process.env.UV_NO_MODIFY_PATH !== void 0) {
-    info("UV_NO_MODIFY_PATH is set, not adding python dir to path");
+    info2("UV_NO_MODIFY_PATH is set, not adding python dir to path");
   } else {
     addPath(inputs.pythonDir);
-    info(`Added ${inputs.pythonDir} to the path`);
+    info2(`Added ${inputs.pythonDir} to the path`);
   }
 }
 function setupPython(inputs) {
   if (inputs.pythonVersion !== "") {
     exportVariable("UV_PYTHON", inputs.pythonVersion);
-    info(`Set UV_PYTHON to ${inputs.pythonVersion}`);
+    info2(`Set UV_PYTHON to ${inputs.pythonVersion}`);
   }
 }
 async function activateEnvironment(inputs) {
@@ -97597,7 +97615,7 @@ async function activateEnvironment(inputs) {
         "UV_NO_MODIFY_PATH and activate-environment cannot be used together."
       );
     }
-    info(`Creating and activating python venv at ${inputs.venvPath}...`);
+    info2(`Creating and activating python venv at ${inputs.venvPath}...`);
     const venvArgs = [
       "venv",
       inputs.venvPath,
@@ -97621,13 +97639,13 @@ async function activateEnvironment(inputs) {
 function setCacheDir(inputs) {
   if (inputs.cacheLocalPath !== void 0) {
     if (inputs.cacheLocalPath.source === 1 /* Config */) {
-      info(
+      info2(
         "Using cache-dir from uv config file, not modifying UV_CACHE_DIR"
       );
       return;
     }
     exportVariable("UV_CACHE_DIR", inputs.cacheLocalPath.path);
-    info(`Set UV_CACHE_DIR to ${inputs.cacheLocalPath.path}`);
+    info2(`Set UV_CACHE_DIR to ${inputs.cacheLocalPath.path}`);
   }
 }
 function addMatchers(inputs) {

--- a/dist/update-known-checksums/index.cjs
+++ b/dist/update-known-checksums/index.cjs
@@ -153,18 +153,18 @@ var require_tunnel = __commonJS({
             res.statusCode
           );
           socket.destroy();
-          var error = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
         if (head.length > 0) {
           debug2("got illegal response body from proxy");
           socket.destroy();
-          var error = new Error("got illegal response body from proxy");
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("got illegal response body from proxy");
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
@@ -179,9 +179,9 @@ var require_tunnel = __commonJS({
           cause.message,
           cause.stack
         );
-        var error = new Error("tunneling socket could not be established, cause=" + cause.message);
-        error.code = "ECONNRESET";
-        options.request.emit("error", error);
+        var error2 = new Error("tunneling socket could not be established, cause=" + cause.message);
+        error2.code = "ECONNRESET";
+        options.request.emit("error", error2);
         self.removeSocket(placeholder);
       }
     };
@@ -1510,14 +1510,14 @@ var require_diagnostics = __commonJS({
       diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
         const {
           connectParams: { version, protocol, port, host },
-          error
+          error: error2
         } = evt;
         debuglog(
           "connection to %s using %s%s errored - %s",
           `${host}${port ? `:${port}` : ""}`,
           protocol,
           version,
-          error.message
+          error2.message
         );
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
@@ -1548,14 +1548,14 @@ var require_diagnostics = __commonJS({
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
           request: { method, path, origin },
-          error
+          error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
           path,
-          error.message
+          error2.message
         );
       });
       isClientSet = true;
@@ -1590,7 +1590,7 @@ var require_diagnostics = __commonJS({
         diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
           const {
             connectParams: { version, protocol, port, host },
-            error
+            error: error2
           } = evt;
           debuglog(
             "connection to %s%s using %s%s errored - %s",
@@ -1598,7 +1598,7 @@ var require_diagnostics = __commonJS({
             port ? `:${port}` : "",
             protocol,
             version,
-            error.message
+            error2.message
           );
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
@@ -1868,16 +1868,16 @@ var require_request = __commonJS({
           this.onError(err);
         }
       }
-      onError(error) {
+      onError(error2) {
         this.onFinally();
         if (channels.error.hasSubscribers) {
-          channels.error.publish({ request: this, error });
+          channels.error.publish({ request: this, error: error2 });
         }
         if (this.aborted) {
           return;
         }
         this.aborted = true;
-        return this[kHandler].onError(error);
+        return this[kHandler].onError(error2);
       }
       onFinally() {
         if (this.errorHandler) {
@@ -5600,7 +5600,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
       }
       throwIfAborted(object[kState]);
       const promise = createDeferredPromise();
-      const errorSteps = (error) => promise.reject(error);
+      const errorSteps = (error2) => promise.reject(error2);
       const successSteps = (data) => {
         try {
           promise.resolve(convertBytesToJSValue(data));
@@ -7108,8 +7108,8 @@ var require_client_h2 = __commonJS({
         }
         request.onRequestSent();
         client[kResume]();
-      } catch (error) {
-        abort(error);
+      } catch (error2) {
+        abort(error2);
       }
     }
     function writeStream(abort, socket, expectsPayload, h2stream, body, client, request, contentLength) {
@@ -7264,8 +7264,8 @@ var require_redirect_handler = __commonJS({
       onUpgrade(statusCode, headers, socket) {
         this.handler.onUpgrade(statusCode, headers, socket);
       }
-      onError(error) {
-        this.handler.onError(error);
+      onError(error2) {
+        this.handler.onError(error2);
       }
       onHeaders(statusCode, headers, resume, statusText) {
         this.location = this.history.length >= this.maxRedirections || util.isDisturbed(this.opts.body) ? null : parseLocation(statusCode, headers);
@@ -8193,7 +8193,7 @@ var require_pool = __commonJS({
         this[kOptions] = { ...util.deepClone(options), connect, allowH2 };
         this[kOptions].interceptors = options.interceptors ? { ...options.interceptors } : void 0;
         this[kFactory] = factory;
-        this.on("connectionError", (origin2, targets, error) => {
+        this.on("connectionError", (origin2, targets, error2) => {
           for (const target of targets) {
             const idx = this[kClients].indexOf(target);
             if (idx !== -1) {
@@ -10560,13 +10560,13 @@ var require_mock_utils = __commonJS({
       if (mockDispatch2.data.callback) {
         mockDispatch2.data = { ...mockDispatch2.data, ...mockDispatch2.data.callback(opts) };
       }
-      const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch2;
+      const { data: { statusCode, data, headers, trailers, error: error2 }, delay, persist } = mockDispatch2;
       const { timesInvoked, times } = mockDispatch2;
       mockDispatch2.consumed = !persist && timesInvoked >= times;
       mockDispatch2.pending = timesInvoked < times;
-      if (error !== null) {
+      if (error2 !== null) {
         deleteMockDispatch(this[kDispatches], key);
-        handler.onError(error);
+        handler.onError(error2);
         return true;
       }
       if (typeof delay === "number" && delay > 0) {
@@ -10604,19 +10604,19 @@ var require_mock_utils = __commonJS({
         if (agent.isMockActive) {
           try {
             mockDispatch.call(this, opts, handler);
-          } catch (error) {
-            if (error instanceof MockNotMatchedError) {
+          } catch (error2) {
+            if (error2 instanceof MockNotMatchedError) {
               const netConnect = agent[kGetNetConnect]();
               if (netConnect === false) {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
               }
               if (checkNetConnect(netConnect, origin)) {
                 originalDispatch.call(this, opts, handler);
               } else {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
               }
             } else {
-              throw error;
+              throw error2;
             }
           }
         } else {
@@ -10781,11 +10781,11 @@ var require_mock_interceptor = __commonJS({
       /**
        * Mock an undici request with a defined error.
        */
-      replyWithError(error) {
-        if (typeof error === "undefined") {
+      replyWithError(error2) {
+        if (typeof error2 === "undefined") {
           throw new InvalidArgumentError("error must be defined");
         }
-        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error });
+        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error: error2 });
         return new MockScope(newMockDispatch);
       }
       /**
@@ -13303,17 +13303,17 @@ var require_fetch = __commonJS({
         this.emit("terminated", reason);
       }
       // https://fetch.spec.whatwg.org/#fetch-controller-abort
-      abort(error) {
+      abort(error2) {
         if (this.state !== "ongoing") {
           return;
         }
         this.state = "aborted";
-        if (!error) {
-          error = new DOMException("The operation was aborted.", "AbortError");
+        if (!error2) {
+          error2 = new DOMException("The operation was aborted.", "AbortError");
         }
-        this.serializedAbortReason = error;
-        this.connection?.destroy(error);
-        this.emit("terminated", error);
+        this.serializedAbortReason = error2;
+        this.connection?.destroy(error2);
+        this.emit("terminated", error2);
       }
     };
     function handleFetchDone(response) {
@@ -13409,12 +13409,12 @@ var require_fetch = __commonJS({
       );
     }
     var markResourceTiming = performance.markResourceTiming;
-    function abortFetch(p, request, responseObject, error) {
+    function abortFetch(p, request, responseObject, error2) {
       if (p) {
-        p.reject(error);
+        p.reject(error2);
       }
       if (request.body != null && isReadable(request.body?.stream)) {
-        request.body.stream.cancel(error).catch((err) => {
+        request.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -13426,7 +13426,7 @@ var require_fetch = __commonJS({
       }
       const response = responseObject[kState];
       if (response.body != null && isReadable(response.body?.stream)) {
-        response.body.stream.cancel(error).catch((err) => {
+        response.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -14247,13 +14247,13 @@ var require_fetch = __commonJS({
               fetchParams.controller.ended = true;
               this.body.push(null);
             },
-            onError(error) {
+            onError(error2) {
               if (this.abort) {
                 fetchParams.controller.off("terminated", this.abort);
               }
-              this.body?.destroy(error);
-              fetchParams.controller.terminate(error);
-              reject(error);
+              this.body?.destroy(error2);
+              fetchParams.controller.terminate(error2);
+              reject(error2);
             },
             onUpgrade(status, rawHeaders, socket) {
               if (status !== 101) {
@@ -14716,8 +14716,8 @@ var require_util4 = __commonJS({
                   }
                   fr[kResult] = result;
                   fireAProgressEvent("load", fr);
-                } catch (error) {
-                  fr[kError] = error;
+                } catch (error2) {
+                  fr[kError] = error2;
                   fireAProgressEvent("error", fr);
                 }
                 if (fr[kState] !== "loading") {
@@ -14726,13 +14726,13 @@ var require_util4 = __commonJS({
               });
               break;
             }
-          } catch (error) {
+          } catch (error2) {
             if (fr[kAborted]) {
               return;
             }
             queueMicrotask(() => {
               fr[kState] = "done";
-              fr[kError] = error;
+              fr[kError] = error2;
               fireAProgressEvent("error", fr);
               if (fr[kState] !== "loading") {
                 fireAProgressEvent("loadend", fr);
@@ -17004,11 +17004,11 @@ var require_connection = __commonJS({
         });
       }
     }
-    function onSocketError(error) {
+    function onSocketError(error2) {
       const { ws } = this;
       ws[kReadyState] = states.CLOSING;
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(error);
+        channels.socketError.publish(error2);
       }
       this.destroy();
     }
@@ -17275,9 +17275,9 @@ var require_receiver = __commonJS({
                 }
                 this.#state = parserStates.INFO;
               } else {
-                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error, data) => {
-                  if (error) {
-                    failWebsocketConnection(this.ws, error.message);
+                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error2, data) => {
+                  if (error2) {
+                    failWebsocketConnection(this.ws, error2.message);
                     return;
                   }
                   this.#fragments.push(data);
@@ -18309,8 +18309,8 @@ var require_eventsource = __commonJS({
           pipeline(
             response.body.stream,
             eventSourceStream,
-            (error) => {
-              if (error?.aborted === false) {
+            (error2) => {
+              if (error2?.aborted === false) {
                 this.close();
                 this.dispatchEvent(new Event("error"));
               }
@@ -21649,7 +21649,7 @@ var require_diagnostics2 = __commonJS({
         (evt) => {
           const {
             connectParams: { version, protocol, port, host },
-            error
+            error: error2
           } = evt;
           debugLog(
             "connection to %s%s using %s%s errored - %s",
@@ -21657,7 +21657,7 @@ var require_diagnostics2 = __commonJS({
             port ? `:${port}` : "",
             protocol,
             version,
-            error.message
+            error2.message
           );
         }
       );
@@ -21711,14 +21711,14 @@ var require_diagnostics2 = __commonJS({
         (evt) => {
           const {
             request: { method, path, origin },
-            error
+            error: error2
           } = evt;
           debugLog(
             "request to %s %s%s errored - %s",
             method,
             origin,
             path,
-            error.message
+            error2.message
           );
         }
       );
@@ -22037,16 +22037,16 @@ var require_request3 = __commonJS({
           this.onError(err);
         }
       }
-      onError(error) {
+      onError(error2) {
         this.onFinally();
         if (channels.error.hasSubscribers) {
-          channels.error.publish({ request: this, error });
+          channels.error.publish({ request: this, error: error2 });
         }
         if (this.aborted) {
           return;
         }
         this.aborted = true;
-        return this[kHandler].onError(error);
+        return this[kHandler].onError(error2);
       }
       onFinally() {
         if (this.errorHandler) {
@@ -27576,9 +27576,9 @@ var require_client_h22 = __commonJS({
         const client = this[kClient];
         const socket = this[kClient];
         if (err != null) {
-          const error = new InformationalError(`HTTP/2: "PING" errored - type ${err.message}`);
-          socket[kError] = error;
-          client[kOnError](error);
+          const error2 = new InformationalError(`HTTP/2: "PING" errored - type ${err.message}`);
+          socket[kError] = error2;
+          client[kOnError](error2);
         } else {
           client.emit("ping", duration);
         }
@@ -27994,8 +27994,8 @@ var require_client_h22 = __commonJS({
         }
         request.onRequestSent();
         client[kResume]();
-      } catch (error) {
-        abort(error);
+      } catch (error2) {
+        abort(error2);
       }
     }
     function writeStream(abort, socket, expectsPayload, h2stream, body, client, request, contentLength) {
@@ -28926,7 +28926,7 @@ var require_pool2 = __commonJS({
             }
           }
         });
-        this.on("connectionError", (origin2, targets, error) => {
+        this.on("connectionError", (origin2, targets, error2) => {
           for (const target of targets) {
             const idx = this[kClients].indexOf(target);
             if (idx !== -1) {
@@ -29178,7 +29178,7 @@ var require_round_robin_pool = __commonJS({
             }
           }
         });
-        this.on("connectionError", (origin2, targets, error) => {
+        this.on("connectionError", (origin2, targets, error2) => {
           for (const target of targets) {
             const idx = this[kClients].indexOf(target);
             if (idx !== -1) {
@@ -29491,9 +29491,9 @@ var require_socks5_utils = __commonJS({
         8: "Address type not supported"
       };
       const message = messages[replyCode] || `Unknown SOCKS5 error code: ${replyCode}`;
-      const error = new Error(message);
-      error.code = `SOCKS5_${replyCode}`;
-      return error;
+      const error2 = new Error(message);
+      error2.code = `SOCKS5_${replyCode}`;
+      return error2;
     }
     module2.exports = {
       parseAddress,
@@ -29931,8 +29931,8 @@ var require_socks5_proxy_agent = __commonJS({
           const timeout = setTimeout(() => {
             reject(new Error("SOCKS5 connection timeout"));
           }, 5e3);
-          const onConnected = (info2) => {
-            debug2("SOCKS5 tunnel established to", targetHost, targetPort, "via", info2);
+          const onConnected = (info3) => {
+            debug2("SOCKS5 tunnel established to", targetHost, targetPort, "via", info3);
             clearTimeout(timeout);
             socks5Client.removeListener("error", onError);
             resolve();
@@ -32269,13 +32269,13 @@ var require_mock_utils2 = __commonJS({
       if (mockDispatch2.data.callback) {
         mockDispatch2.data = { ...mockDispatch2.data, ...mockDispatch2.data.callback(opts) };
       }
-      const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch2;
+      const { data: { statusCode, data, headers, trailers, error: error2 }, delay, persist } = mockDispatch2;
       const { timesInvoked, times } = mockDispatch2;
       mockDispatch2.consumed = !persist && timesInvoked >= times;
       mockDispatch2.pending = timesInvoked < times;
-      if (error !== null) {
+      if (error2 !== null) {
         deleteMockDispatch(this[kDispatches], key);
-        handler.onError(error);
+        handler.onError(error2);
         return true;
       }
       let aborted = false;
@@ -32332,19 +32332,19 @@ var require_mock_utils2 = __commonJS({
         if (agent.isMockActive) {
           try {
             mockDispatch.call(this, opts, handler);
-          } catch (error) {
-            if (error.code === "UND_MOCK_ERR_MOCK_NOT_MATCHED") {
+          } catch (error2) {
+            if (error2.code === "UND_MOCK_ERR_MOCK_NOT_MATCHED") {
               const netConnect = agent[kGetNetConnect]();
               if (netConnect === false) {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
               }
               if (checkNetConnect(netConnect, origin)) {
                 originalDispatch.call(this, opts, handler);
               } else {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
               }
             } else {
-              throw error;
+              throw error2;
             }
           }
         } else {
@@ -32529,11 +32529,11 @@ var require_mock_interceptor2 = __commonJS({
       /**
        * Mock an undici request with a defined error.
        */
-      replyWithError(error) {
-        if (typeof error === "undefined") {
+      replyWithError(error2) {
+        if (typeof error2 === "undefined") {
           throw new InvalidArgumentError("error must be defined");
         }
-        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error }, { ignoreTrailingSlash: this[kIgnoreTrailingSlash] });
+        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error: error2 }, { ignoreTrailingSlash: this[kIgnoreTrailingSlash] });
         return new MockScope(newMockDispatch);
       }
       /**
@@ -32683,8 +32683,8 @@ var require_mock_call_history = __commonJS({
         }
         url.search = new URLSearchParams(requestInit.query).toString();
         return url;
-      } catch (error) {
-        throw new InvalidArgumentError("An error occurred when computing MockCallHistoryLog.url", { cause: error });
+      } catch (error2) {
+        throw new InvalidArgumentError("An error occurred when computing MockCallHistoryLog.url", { cause: error2 });
       }
     }
     var MockCallHistoryLog = class {
@@ -33418,11 +33418,11 @@ var require_snapshot_recorder = __commonJS({
           } else {
             this.#snapshots = new Map(Object.entries(parsed));
           }
-        } catch (error) {
-          if (error.code === "ENOENT") {
+        } catch (error2) {
+          if (error2.code === "ENOENT") {
             this.#snapshots.clear();
           } else {
-            throw new UndiciError(`Failed to load snapshots from ${path}`, { cause: error });
+            throw new UndiciError(`Failed to load snapshots from ${path}`, { cause: error2 });
           }
         }
       }
@@ -33656,12 +33656,12 @@ var require_snapshot_agent = __commonJS({
           } else if (mode === "update") {
             return this.#recordAndReplay(opts, handler);
           } else {
-            const error = new UndiciError(`No snapshot found for ${opts.method || "GET"} ${opts.path}`);
+            const error2 = new UndiciError(`No snapshot found for ${opts.method || "GET"} ${opts.path}`);
             if (handler.onError) {
-              handler.onError(error);
+              handler.onError(error2);
               return;
             }
-            throw error;
+            throw error2;
           }
         } else if (mode === "record") {
           return this.#recordAndReplay(opts, handler);
@@ -33709,7 +33709,7 @@ var require_snapshot_agent = __commonJS({
               headers: responseData.headers,
               body: responseBody,
               trailers: responseData.trailers
-            }).then(() => handler.onResponseEnd(controller, trailers)).catch((error) => handler.onResponseError(controller, error));
+            }).then(() => handler.onResponseEnd(controller, trailers)).catch((error2) => handler.onResponseError(controller, error2));
           }
         };
         const agent = this[kRealAgent];
@@ -33742,8 +33742,8 @@ var require_snapshot_agent = __commonJS({
           const body = Buffer.from(response.body, "base64");
           handler.onResponseData(controller, body);
           handler.onResponseEnd(controller, response.trailers);
-        } catch (error) {
-          handler.onError?.(error);
+        } catch (error2) {
+          handler.onError?.(error2);
         }
       }
       /**
@@ -34087,8 +34087,8 @@ var require_redirect_handler2 = __commonJS({
           this.handler.onResponseEnd(controller, trailers);
         }
       }
-      onResponseError(controller, error) {
-        this.handler.onResponseError?.(controller, error);
+      onResponseError(controller, error2) {
+        this.handler.onResponseError?.(controller, error2);
       }
     };
     function shouldRemoveHeader(header, removeContent, unknownOrigin) {
@@ -36609,8 +36609,8 @@ var require_decompress = __commonJS({
             }
           }
         });
-        decompressor.on("error", (error) => {
-          super.onResponseError(controller, error);
+        decompressor.on("error", (error2) => {
+          super.onResponseError(controller, error2);
         });
       }
       /**
@@ -39404,17 +39404,17 @@ var require_fetch2 = __commonJS({
         this.emit("terminated", reason);
       }
       // https://fetch.spec.whatwg.org/#fetch-controller-abort
-      abort(error) {
+      abort(error2) {
         if (this.state !== "ongoing") {
           return;
         }
         this.state = "aborted";
-        if (!error) {
-          error = new DOMException("The operation was aborted.", "AbortError");
+        if (!error2) {
+          error2 = new DOMException("The operation was aborted.", "AbortError");
         }
-        this.serializedAbortReason = error;
-        this.connection?.destroy(error);
-        this.emit("terminated", error);
+        this.serializedAbortReason = error2;
+        this.connection?.destroy(error2);
+        this.emit("terminated", error2);
       }
     };
     function handleFetchDone(response) {
@@ -39516,12 +39516,12 @@ var require_fetch2 = __commonJS({
       );
     }
     var markResourceTiming = performance.markResourceTiming;
-    function abortFetch(p, request, responseObject, error, controller) {
+    function abortFetch(p, request, responseObject, error2, controller) {
       if (p) {
-        p.reject(error);
+        p.reject(error2);
       }
       if (request.body?.stream != null && isReadable(request.body.stream)) {
-        request.body.stream.cancel(error).catch((err) => {
+        request.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -39533,7 +39533,7 @@ var require_fetch2 = __commonJS({
       }
       const response = getResponseState(responseObject);
       if (response.body?.stream != null && isReadable(response.body.stream)) {
-        controller.error(error);
+        controller.error(error2);
       }
     }
     function fetching({
@@ -40377,13 +40377,13 @@ var require_fetch2 = __commonJS({
               fetchParams.controller.ended = true;
               this.body.push(null);
             },
-            onError(error) {
+            onError(error2) {
               if (this.abort) {
                 fetchParams.controller.off("terminated", this.abort);
               }
-              this.body?.destroy(error);
-              fetchParams.controller.terminate(error);
-              reject(error);
+              this.body?.destroy(error2);
+              fetchParams.controller.terminate(error2);
+              reject(error2);
             },
             onRequestUpgrade(_controller, status, headers, socket) {
               if (socket.session != null && status !== 200 || socket.session == null && status !== 101) {
@@ -42605,10 +42605,10 @@ var require_receiver2 = __commonJS({
                 }
                 this.#state = parserStates.INFO;
               } else {
-                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error, data) => {
-                  if (error) {
-                    const code = error instanceof MessageSizeExceededError ? 1009 : 1007;
-                    failWebsocketConnection(this.#handler, code, error.message);
+                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error2, data) => {
+                  if (error2) {
+                    const code = error2 instanceof MessageSizeExceededError ? 1009 : 1007;
+                    failWebsocketConnection(this.#handler, code, error2.message);
                     return;
                   }
                   this.writeFragments(data);
@@ -43380,10 +43380,10 @@ var require_websocketerror = __commonJS({
        * @param {string} reason
        */
       static createUnvalidatedWebSocketError(message, code, reason) {
-        const error = new _WebSocketError(message, kConstruct);
-        error.#closeCode = code;
-        error.#reason = reason;
-        return error;
+        const error2 = new _WebSocketError(message, kConstruct);
+        error2.#closeCode = code;
+        error2.#reason = reason;
+        return error2;
       }
     };
     var { createUnvalidatedWebSocketError } = WebSocketError;
@@ -43650,10 +43650,10 @@ var require_websocketstream = __commonJS({
             reason
           });
         } else {
-          const error = createUnvalidatedWebSocketError("unclean close", code, reason);
-          this.#readableStreamController?.error(error);
-          this.#writableStream?.abort(error);
-          this.#closedPromise.reject(error);
+          const error2 = createUnvalidatedWebSocketError("unclean close", code, reason);
+          this.#readableStreamController?.error(error2);
+          this.#writableStream?.abort(error2);
+          this.#closedPromise.reject(error2);
         }
       }
       #closeUsingReason(reason) {
@@ -44132,8 +44132,8 @@ var require_eventsource2 = __commonJS({
           pipeline(
             response.body.stream,
             eventSourceStream,
-            (error) => {
-              if (error?.aborted === false) {
+            (error2) => {
+              if (error2?.aborted === false) {
                 this.close();
                 this.dispatchEvent(new Event("error"));
               }
@@ -44929,6 +44929,16 @@ var ExitCode;
   ExitCode2[ExitCode2["Success"] = 0] = "Success";
   ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
 })(ExitCode || (ExitCode = {}));
+function getInput(name, options) {
+  const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+  if (options && options.required && !val) {
+    throw new Error(`Input required and not supplied: ${name}`);
+  }
+  if (options && options.trimWhitespace === false) {
+    return val;
+  }
+  return val.trim();
+}
 function setOutput(name, value) {
   const filePath = process.env["GITHUB_OUTPUT"] || "";
   if (filePath) {
@@ -49760,6 +49770,20 @@ var fetch = async (url, opts) => {
   });
 };
 
+// src/utils/logging.ts
+var quiet;
+function isQuiet() {
+  if (quiet === void 0) {
+    quiet = typeof getInput === "function" && getInput("quiet") === "true";
+  }
+  return quiet;
+}
+function info2(msg) {
+  if (!isQuiet()) {
+    info(msg);
+  }
+}
+
 // src/download/manifest.ts
 var cachedManifestData = /* @__PURE__ */ new Map();
 async function fetchManifest(manifestUrl = VERSIONS_MANIFEST_URL) {
@@ -49768,7 +49792,7 @@ async function fetchManifest(manifestUrl = VERSIONS_MANIFEST_URL) {
     debug(`Using cached manifest data from ${manifestUrl}`);
     return cachedVersions;
   }
-  info(`Fetching manifest data from ${manifestUrl} ...`);
+  info2(`Fetching manifest data from ${manifestUrl} ...`);
   const response = await fetch(manifestUrl, {});
   if (!response.ok) {
     throw new Error(
@@ -49799,9 +49823,9 @@ function parseManifest(data, sourceDescription) {
     let parsed;
     try {
       parsed = JSON.parse(record);
-    } catch (error) {
+    } catch (error2) {
       throw new Error(
-        `Failed to parse manifest data from ${sourceDescription} at line ${index + 1}: ${error.message}`
+        `Failed to parse manifest data from ${sourceDescription} at line ${index + 1}: ${error2.message}`
       );
     }
     if (!isManifestVersion(parsed)) {
@@ -49856,7 +49880,7 @@ async function run() {
   const latestVersion = await getLatestVersion();
   const latestKnownVersion = getLatestKnownVersionFromChecksums();
   if (semver.lte(latestVersion, latestKnownVersion)) {
-    info(
+    info2(
       `Latest release (${latestVersion}) is not newer than the latest known version (${latestKnownVersion}). Skipping update.`
     );
     return;

--- a/src/cache/restore-cache.ts
+++ b/src/cache/restore-cache.ts
@@ -2,6 +2,7 @@ import * as cache from "@actions/cache";
 import * as core from "@actions/core";
 import { hashFiles } from "../hash/hash-files";
 import type { SetupInputs } from "../utils/inputs";
+import * as log from "../utils/logging";
 import { getArch, getOSNameVersion, getPlatform } from "../utils/platforms";
 
 export const STATE_CACHE_KEY = "cache-key";
@@ -19,7 +20,7 @@ export async function restoreCache(
   core.setOutput("cache-key", cacheKey);
 
   if (!inputs.restoreCache) {
-    core.info("restore-cache is false. Skipping restore cache step.");
+    log.info("restore-cache is false. Skipping restore cache step.");
     core.setOutput("python-cache-hit", false);
     return;
   }
@@ -55,7 +56,7 @@ async function restoreCacheFromKey(
   stateKey: string,
   outputKey: string,
 ): Promise<void> {
-  core.info(
+  log.info(
     `Trying to restore cache from GitHub Actions cache with key: ${cacheKey}`,
   );
   let matchedKey: string | undefined;
@@ -63,7 +64,7 @@ async function restoreCacheFromKey(
     matchedKey = await cache.restoreCache([cachePath], cacheKey);
   } catch (err) {
     const message = (err as Error).message;
-    core.warning(message);
+    log.warning(message);
     core.setOutput(outputKey, false);
     return;
   }
@@ -77,7 +78,7 @@ async function computeKeys(
 ): Promise<string> {
   let cacheDependencyPathHash = "-";
   if (inputs.cacheDependencyGlob !== "") {
-    core.info(
+    log.info(
       `Searching files using cache dependency glob: ${inputs.cacheDependencyGlob.split("\n").join(",")}`,
     );
     cacheDependencyPathHash += await hashFiles(
@@ -85,7 +86,7 @@ async function computeKeys(
       true,
     );
     if (cacheDependencyPathHash === "-") {
-      core.warning(
+      log.warning(
         `No file matched to [${inputs.cacheDependencyGlob.split("\n").join(",")}]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.`,
       );
     }
@@ -109,12 +110,12 @@ function handleMatchResult(
   outputKey: string,
 ): void {
   if (!matchedKey) {
-    core.info(`No GitHub Actions cache found for key: ${primaryKey}`);
+    log.info(`No GitHub Actions cache found for key: ${primaryKey}`);
     core.setOutput(outputKey, false);
     return;
   }
 
   core.saveState(stateKey, matchedKey);
-  core.info(`cache restored from GitHub Actions cache with key: ${matchedKey}`);
+  log.info(`cache restored from GitHub Actions cache with key: ${matchedKey}`);
   core.setOutput(outputKey, true);
 }

--- a/src/download/download-version.ts
+++ b/src/download/download-version.ts
@@ -8,6 +8,7 @@ import {
   TOOL_CACHE_NAME,
   VERSIONS_MANIFEST_URL,
 } from "../utils/constants";
+import * as log from "../utils/logging";
 import type { Architecture, Platform } from "../utils/platforms";
 import { validateChecksum } from "./checksum/checksum";
 import { getArtifact } from "./manifest";
@@ -73,7 +74,7 @@ export async function downloadVersion(
       throw err;
     }
 
-    core.warning(
+    log.warning(
       `Failed to download from mirror, falling back to GitHub Releases: ${(err as Error).message}`,
     );
 
@@ -123,7 +124,7 @@ async function downloadArtifact(
   checksum: string | undefined,
   githubToken: string | undefined,
 ): Promise<{ version: string; cachedToolDir: string }> {
-  core.info(`Downloading uv from "${downloadUrl}" ...`);
+  log.info(`Downloading uv from "${downloadUrl}" ...`);
   const downloadPath = await tc.downloadTool(
     downloadUrl,
     undefined,
@@ -139,7 +140,7 @@ async function downloadArtifact(
       // so this may fail if another tar, like gnu tar, ends up being used.
       uvDir = await tc.extractTar(downloadPath, undefined, "x");
     } catch (err) {
-      core.info(
+      log.info(
         `Extracting with tar failed, falling back to zip extraction: ${(err as Error).message}`,
       );
       const extension = getExtension(platform);

--- a/src/download/manifest.ts
+++ b/src/download/manifest.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import { VERSIONS_MANIFEST_URL } from "../utils/constants";
 import { fetch } from "../utils/fetch";
+import * as log from "../utils/logging";
 import { selectDefaultVariant } from "./variant-selection";
 
 export interface ManifestArtifact {
@@ -33,7 +34,7 @@ export async function fetchManifest(
     return cachedVersions;
   }
 
-  core.info(`Fetching manifest data from ${manifestUrl} ...`);
+  log.info(`Fetching manifest data from ${manifestUrl} ...`);
   const response = await fetch(manifestUrl, {});
   if (!response.ok) {
     throw new Error(
@@ -111,7 +112,7 @@ export async function getLatestVersion(
 export async function getAllVersions(
   manifestUrl: string = VERSIONS_MANIFEST_URL,
 ): Promise<string[]> {
-  core.info(
+  log.info(
     `Getting available versions from ${manifestSource(manifestUrl)} ...`,
   );
   const versions = await fetchManifest(manifestUrl);

--- a/src/hash/hash-files.ts
+++ b/src/hash/hash-files.ts
@@ -2,8 +2,8 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as stream from "node:stream";
 import * as util from "node:util";
-import * as core from "@actions/core";
 import { create } from "@actions/glob";
+import * as log from "../utils/logging";
 
 /**
  * Hashes files matching the given glob pattern.
@@ -19,7 +19,7 @@ export async function hashFiles(
 ): Promise<string> {
   const globber = await create(pattern);
   let hasMatch = false;
-  const writeDelegate = verbose ? core.info : core.debug;
+  const writeDelegate = verbose ? log.info : log.debug;
   const result = crypto.createHash("sha256");
   let count = 0;
   for await (const file of globber.globGenerator()) {

--- a/src/save-cache.ts
+++ b/src/save-cache.ts
@@ -10,6 +10,7 @@ import {
 } from "./cache/restore-cache";
 import { STATE_UV_PATH, STATE_UV_VERSION } from "./utils/constants";
 import { loadInputs, type SetupInputs } from "./utils/inputs";
+import * as log from "./utils/logging";
 
 function formatUnexpectedFailure(error: unknown): string {
   if (error instanceof Error) {
@@ -38,7 +39,7 @@ export async function run(): Promise<void> {
       if (inputs.saveCache) {
         await saveCache(inputs);
       } else {
-        core.info("save-cache is false. Skipping save cache step.");
+        log.info("save-cache is false. Skipping save cache step.");
       }
       // https://github.com/nodejs/node/issues/56645#issuecomment-3924958861
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -61,11 +62,11 @@ async function saveCache(inputs: SetupInputs): Promise<void> {
   const matchedKey = core.getState(STATE_CACHE_MATCHED_KEY);
 
   if (!cacheKey) {
-    core.warning("Error retrieving cache key from state.");
+    log.warning("Error retrieving cache key from state.");
     return;
   }
   if (matchedKey === cacheKey) {
-    core.info(`Cache hit occurred on key ${cacheKey}, not saving cache.`);
+    log.info(`Cache hit occurred on key ${cacheKey}, not saving cache.`);
   } else {
     if (inputs.pruneCache) {
       await pruneCache();
@@ -74,7 +75,7 @@ async function saveCache(inputs: SetupInputs): Promise<void> {
     const actualCachePath = getUvCachePath(inputs);
     if (!fs.existsSync(actualCachePath)) {
       if (inputs.ignoreNothingToCache) {
-        core.info(
+        log.info(
           "No cacheable uv cache paths were found. Ignoring because ignore-nothing-to-cache is enabled.",
         );
       } else {
@@ -94,7 +95,7 @@ async function saveCache(inputs: SetupInputs): Promise<void> {
 
   if (inputs.cachePython) {
     if (!fs.existsSync(inputs.pythonDir)) {
-      core.warning(
+      log.warning(
         `Python cache path ${inputs.pythonDir} does not exist on disk. Skipping Python cache save because no managed Python installation was found. If you want uv to install managed Python instead of using a system interpreter, set UV_PYTHON_PREFERENCE=only-managed.`,
       );
       return;
@@ -121,7 +122,7 @@ async function pruneCache(): Promise<void> {
     execArgs.push("--force");
   }
 
-  core.info("Pruning cache...");
+  log.info("Pruning cache...");
   const uvPath = core.getState(STATE_UV_PATH);
   await exec.exec(uvPath, execArgs, options);
 }
@@ -136,7 +137,7 @@ function getUvCachePath(inputs: SetupInputs): string {
     process.env.UV_CACHE_DIR &&
     process.env.UV_CACHE_DIR !== inputs.cacheLocalPath.path
   ) {
-    core.warning(
+    log.warning(
       `The environment variable UV_CACHE_DIR has been changed to "${process.env.UV_CACHE_DIR}", by an action or step running after astral-sh/setup-uv. This can lead to unexpected behavior. If you expected this to happen set the cache-local-path input to "${process.env.UV_CACHE_DIR}" instead of "${inputs.cacheLocalPath.path}".`,
     );
     return process.env.UV_CACHE_DIR;
@@ -153,15 +154,13 @@ async function saveCacheToKey(
   const matchedKey = core.getState(stateKey);
 
   if (matchedKey === cacheKey) {
-    core.info(
-      `${cacheName} hit occurred on key ${cacheKey}, not saving cache.`,
-    );
+    log.info(`${cacheName} hit occurred on key ${cacheKey}, not saving cache.`);
     return;
   }
 
-  core.info(`Including ${cacheName} path: ${cachePath}`);
+  log.info(`Including ${cacheName} path: ${cachePath}`);
   await cache.saveCache([cachePath], cacheKey);
-  core.info(`${cacheName} saved with key: ${cacheKey}`);
+  log.info(`${cacheName} saved with key: ${cacheKey}`);
 }
 
 run();

--- a/src/setup-uv.ts
+++ b/src/setup-uv.ts
@@ -9,6 +9,7 @@ import {
 } from "./download/download-version";
 import { STATE_UV_PATH, STATE_UV_VERSION } from "./utils/constants";
 import { CacheLocalSource, loadInputs, type SetupInputs } from "./utils/inputs";
+import * as log from "./utils/logging";
 import {
   type Architecture,
   getArch,
@@ -96,7 +97,7 @@ async function run(): Promise<void> {
 
     core.setOutput("uv-version", setupResult.version);
     core.saveState(STATE_UV_VERSION, setupResult.version);
-    core.info(`Successfully installed uv version ${setupResult.version}`);
+    log.info(`Successfully installed uv version ${setupResult.version}`);
 
     const detectedPythonVersion = await getPythonVersion(inputs);
     core.setOutput("python-version", detectedPythonVersion);
@@ -115,11 +116,11 @@ async function run(): Promise<void> {
 function detectEmptyWorkdir(inputs: SetupInputs): void {
   if (fs.readdirSync(inputs.workingDirectory).length === 0) {
     if (inputs.ignoreEmptyWorkdir) {
-      core.info(
+      log.info(
         "Empty workdir detected. Ignoring because ignore-empty-workdir is enabled",
       );
     } else {
-      core.warning(
+      log.warning(
         "Empty workdir detected. This may cause unexpected behavior. You can enable ignore-empty-workdir to mute this warning.",
       );
     }
@@ -140,7 +141,7 @@ async function setupUv(
   });
   const toolCacheResult = tryGetFromToolCache(arch, resolvedVersion);
   if (toolCacheResult.installedPath) {
-    core.info(`Found uv in tool-cache for ${toolCacheResult.version}`);
+    log.info(`Found uv in tool-cache for ${toolCacheResult.version}`);
     return {
       uvDir: toolCacheResult.installedPath,
       version: toolCacheResult.version,
@@ -168,39 +169,39 @@ function addUvToPathAndOutput(cachedPath: string): void {
   core.saveState(STATE_UV_PATH, `${cachedPath}${path.sep}uv`);
   core.setOutput("uvx-path", `${cachedPath}${path.sep}uvx`);
   if (process.env.UV_NO_MODIFY_PATH !== undefined) {
-    core.info("UV_NO_MODIFY_PATH is set, not modifying PATH");
+    log.info("UV_NO_MODIFY_PATH is set, not modifying PATH");
   } else {
     core.addPath(cachedPath);
-    core.info(`Added ${cachedPath} to the path`);
+    log.info(`Added ${cachedPath} to the path`);
   }
 }
 
 function addToolBinToPath(inputs: SetupInputs): void {
   if (inputs.toolBinDir !== undefined) {
     core.exportVariable("UV_TOOL_BIN_DIR", inputs.toolBinDir);
-    core.info(`Set UV_TOOL_BIN_DIR to ${inputs.toolBinDir}`);
+    log.info(`Set UV_TOOL_BIN_DIR to ${inputs.toolBinDir}`);
     if (process.env.UV_NO_MODIFY_PATH !== undefined) {
-      core.info(
+      log.info(
         `UV_NO_MODIFY_PATH is set, not adding ${inputs.toolBinDir} to path`,
       );
     } else {
       core.addPath(inputs.toolBinDir);
-      core.info(`Added ${inputs.toolBinDir} to the path`);
+      log.info(`Added ${inputs.toolBinDir} to the path`);
     }
   } else {
     if (process.env.UV_NO_MODIFY_PATH !== undefined) {
-      core.info("UV_NO_MODIFY_PATH is set, not adding user local bin to path");
+      log.info("UV_NO_MODIFY_PATH is set, not adding user local bin to path");
       return;
     }
     if (process.env.XDG_BIN_HOME !== undefined) {
       core.addPath(process.env.XDG_BIN_HOME);
-      core.info(`Added ${process.env.XDG_BIN_HOME} to the path`);
+      log.info(`Added ${process.env.XDG_BIN_HOME} to the path`);
     } else if (process.env.XDG_DATA_HOME !== undefined) {
       core.addPath(`${process.env.XDG_DATA_HOME}/../bin`);
-      core.info(`Added ${process.env.XDG_DATA_HOME}/../bin to the path`);
+      log.info(`Added ${process.env.XDG_DATA_HOME}/../bin to the path`);
     } else {
       core.addPath(`${process.env.HOME}/.local/bin`);
-      core.info(`Added ${process.env.HOME}/.local/bin to the path`);
+      log.info(`Added ${process.env.HOME}/.local/bin to the path`);
     }
   }
 }
@@ -208,25 +209,25 @@ function addToolBinToPath(inputs: SetupInputs): void {
 function setToolDir(inputs: SetupInputs): void {
   if (inputs.toolDir !== undefined) {
     core.exportVariable("UV_TOOL_DIR", inputs.toolDir);
-    core.info(`Set UV_TOOL_DIR to ${inputs.toolDir}`);
+    log.info(`Set UV_TOOL_DIR to ${inputs.toolDir}`);
   }
 }
 
 function addPythonDirToPath(inputs: SetupInputs): void {
   core.exportVariable("UV_PYTHON_INSTALL_DIR", inputs.pythonDir);
-  core.info(`Set UV_PYTHON_INSTALL_DIR to ${inputs.pythonDir}`);
+  log.info(`Set UV_PYTHON_INSTALL_DIR to ${inputs.pythonDir}`);
   if (process.env.UV_NO_MODIFY_PATH !== undefined) {
-    core.info("UV_NO_MODIFY_PATH is set, not adding python dir to path");
+    log.info("UV_NO_MODIFY_PATH is set, not adding python dir to path");
   } else {
     core.addPath(inputs.pythonDir);
-    core.info(`Added ${inputs.pythonDir} to the path`);
+    log.info(`Added ${inputs.pythonDir} to the path`);
   }
 }
 
 function setupPython(inputs: SetupInputs): void {
   if (inputs.pythonVersion !== "") {
     core.exportVariable("UV_PYTHON", inputs.pythonVersion);
-    core.info(`Set UV_PYTHON to ${inputs.pythonVersion}`);
+    log.info(`Set UV_PYTHON to ${inputs.pythonVersion}`);
   }
 }
 
@@ -238,7 +239,7 @@ async function activateEnvironment(inputs: SetupInputs): Promise<void> {
       );
     }
 
-    core.info(`Creating and activating python venv at ${inputs.venvPath}...`);
+    log.info(`Creating and activating python venv at ${inputs.venvPath}...`);
     const venvArgs = [
       "venv",
       inputs.venvPath,
@@ -264,13 +265,13 @@ async function activateEnvironment(inputs: SetupInputs): Promise<void> {
 function setCacheDir(inputs: SetupInputs): void {
   if (inputs.cacheLocalPath !== undefined) {
     if (inputs.cacheLocalPath.source === CacheLocalSource.Config) {
-      core.info(
+      log.info(
         "Using cache-dir from uv config file, not modifying UV_CACHE_DIR",
       );
       return;
     }
     core.exportVariable("UV_CACHE_DIR", inputs.cacheLocalPath.path);
-    core.info(`Set UV_CACHE_DIR to ${inputs.cacheLocalPath.path}`);
+    log.info(`Set UV_CACHE_DIR to ${inputs.cacheLocalPath.path}`);
   }
 }
 

--- a/src/update-known-checksums.ts
+++ b/src/update-known-checksums.ts
@@ -10,6 +10,7 @@ import {
   getLatestVersion,
   type ManifestVersion,
 } from "./download/manifest";
+import * as log from "./utils/logging";
 
 const VERSION_IN_CHECKSUM_KEY_PATTERN =
   /-(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/;
@@ -26,7 +27,7 @@ async function run(): Promise<void> {
   const latestKnownVersion = getLatestKnownVersionFromChecksums();
 
   if (semver.lte(latestVersion, latestKnownVersion)) {
-    core.info(
+    log.info(
       `Latest release (${latestVersion}) is not newer than the latest known version (${latestKnownVersion}). Skipping update.`,
     );
     return;

--- a/src/utils/inputs.ts
+++ b/src/utils/inputs.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import * as core from "@actions/core";
 import { getConfigValueFromTomlFile } from "./config-file";
+import * as log from "./logging";
 
 export enum CacheLocalSource {
   Input,
@@ -42,6 +43,7 @@ export interface SetupInputs {
   manifestFile?: string;
   downloadFromAstralMirror: boolean;
   addProblemMatchers: boolean;
+  quiet: boolean;
   resolutionStrategy: ResolutionStrategy;
 }
 
@@ -77,6 +79,7 @@ export function loadInputs(): SetupInputs {
   const downloadFromAstralMirror =
     core.getInput("download-from-astral-mirror") === "true";
   const addProblemMatchers = core.getInput("add-problem-matchers") === "true";
+  const quiet = core.getInput("quiet") === "true";
   const resolutionStrategy = getResolutionStrategy();
 
   return {
@@ -97,6 +100,7 @@ export function loadInputs(): SetupInputs {
     pruneCache,
     pythonDir,
     pythonVersion,
+    quiet,
     resolutionStrategy,
     restoreCache,
     saveCache,
@@ -125,7 +129,7 @@ function getVenvPath(
   const venvPathInput = core.getInput("venv-path");
   if (venvPathInput !== "") {
     if (!activateEnvironment) {
-      core.warning("venv-path is only used when activate-environment is true");
+      log.warning("venv-path is only used when activate-environment is true");
     }
     const tildeExpanded = expandTilde(venvPathInput);
     return normalizePath(resolveRelativePath(workingDirectory, tildeExpanded));
@@ -196,7 +200,7 @@ function getCacheLocalPath(
     return { path: cacheDirFromConfig, source: CacheLocalSource.Config };
   }
   if (process.env.UV_CACHE_DIR !== undefined) {
-    core.info(`UV_CACHE_DIR is already set to ${process.env.UV_CACHE_DIR}`);
+    log.info(`UV_CACHE_DIR is already set to ${process.env.UV_CACHE_DIR}`);
     return { path: process.env.UV_CACHE_DIR, source: CacheLocalSource.Env };
   }
   if (enableCache) {
@@ -233,12 +237,12 @@ function getCacheDirFromConfig(
     try {
       const cacheDir = getConfigValueFromTomlFile(resolvedPath, "cache-dir");
       if (cacheDir !== undefined) {
-        core.info(`Found cache-dir in ${resolvedPath}: ${cacheDir}`);
+        log.info(`Found cache-dir in ${resolvedPath}: ${cacheDir}`);
         return cacheDir;
       }
     } catch (err) {
       const message = (err as Error).message;
-      core.warning(`Error while parsing ${filePath}: ${message}`);
+      log.warning(`Error while parsing ${filePath}: ${message}`);
       return undefined;
     }
   }
@@ -247,7 +251,7 @@ function getCacheDirFromConfig(
 
 export function getUvPythonDir(): string {
   if (process.env.UV_PYTHON_INSTALL_DIR !== undefined) {
-    core.info(
+    log.info(
       `UV_PYTHON_INSTALL_DIR is already set to ${process.env.UV_PYTHON_INSTALL_DIR}`,
     );
     return process.env.UV_PYTHON_INSTALL_DIR;

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,0 +1,21 @@
+import * as core from "@actions/core";
+
+let quiet: boolean | undefined;
+
+function isQuiet(): boolean {
+  if (quiet === undefined) {
+    quiet =
+      typeof core.getInput === "function" && core.getInput("quiet") === "true";
+  }
+  return quiet;
+}
+
+export function info(msg: string): void {
+  if (!isQuiet()) {
+    core.info(msg);
+  }
+}
+
+export const warning = core.warning;
+export const error = core.error;
+export const debug = core.debug;

--- a/src/version/file-parser.ts
+++ b/src/version/file-parser.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import * as core from "@actions/core";
 import { getConfigValueFromTomlContent } from "../utils/config-file";
+import * as log from "../utils/logging";
 import {
   getUvVersionFromParsedPyproject,
   getUvVersionFromRequirementsText,
@@ -62,10 +62,10 @@ const VERSION_FILE_PARSERS: VersionFileParser[] = [
 export function getParsedVersionFile(
   filePath: string,
 ): ParsedVersionFile | undefined {
-  core.info(`Trying to find version for uv in: ${filePath}`);
+  log.info(`Trying to find version for uv in: ${filePath}`);
 
   if (!fs.existsSync(filePath)) {
-    core.info(`Could not find file: ${filePath}`);
+    log.info(`Could not find file: ${filePath}`);
     return undefined;
   }
 
@@ -81,15 +81,13 @@ export function getParsedVersionFile(
     }
 
     const normalizedSpecifier = normalizeVersionSpecifier(specifier);
-    core.info(`Found version for uv in ${filePath}: ${normalizedSpecifier}`);
+    log.info(`Found version for uv in ${filePath}: ${normalizedSpecifier}`);
     return {
       format: parser.format,
       specifier: normalizedSpecifier,
     };
   } catch (error) {
-    core.warning(
-      `Error while parsing ${filePath}: ${(error as Error).message}`,
-    );
+    log.warning(`Error while parsing ${filePath}: ${(error as Error).message}`);
     return undefined;
   }
 }

--- a/src/version/resolve.ts
+++ b/src/version/resolve.ts
@@ -4,6 +4,7 @@ import * as pep440 from "@renovatebot/pep440";
 import * as semver from "semver";
 import { getAllVersions, getLatestVersion } from "../download/manifest";
 import type { ResolutionStrategy } from "../utils/inputs";
+import * as log from "../utils/logging";
 import {
   type ParsedVersionSpecifier,
   parseVersionSpecifier,
@@ -56,7 +57,7 @@ class LatestVersionResolver implements ConcreteVersionResolver {
       context.parsedSpecifier.kind === "range" &&
       context.parsedSpecifier.isSimpleMinimumVersionSpecifier
     ) {
-      core.info("Found minimum version specifier, using latest version");
+      log.info("Found minimum version specifier, using latest version");
     }
 
     const latestVersion = await getLatestVersion(context.manifestUrl);

--- a/src/version/version-request-resolver.ts
+++ b/src/version/version-request-resolver.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import * as core from "@actions/core";
+import * as log from "../utils/logging";
 import { getParsedVersionFile } from "./file-parser";
 import { normalizeVersionSpecifier } from "./specifier";
 import type {
@@ -111,7 +111,7 @@ export class WorkspaceVersionResolver implements VersionRequestResolver {
       };
     }
 
-    core.info(
+    log.info(
       "Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest.",
     );
     return undefined;


### PR DESCRIPTION
## Summary

Adds a new `quiet` input (default: `false`) that suppresses `info`-level log output when set to `true`. Only warnings and errors are shown.

Contributes to: #868