### PR TITLE
fix: use BUILD_ID as backup for determining os version

### DIFF
--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -91160,11 +91160,15 @@ function getLinuxOSNameVersion() {
       const id = parseOsReleaseValue(content, "ID");
       const versionId2 = parseOsReleaseValue(content, "VERSION_ID");
       const versionCodename = parseOsReleaseValue(content, "VERSION_CODENAME");
+      const buildId = parseOsReleaseValue(content, "BUILD_ID");
       if (id && versionId2) {
         return `${id}-${versionId2}`;
       }
       if (id && versionCodename) {
         return `${id}-${versionCodename}`;
+      }
+      if (id && buildId) {
+        return `${id}-${buildId}`;
       }
     } catch {
     }

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -109,14 +109,18 @@ function getLinuxOSNameVersion(): string {
       const id = parseOsReleaseValue(content, "ID");
       const versionId = parseOsReleaseValue(content, "VERSION_ID");
       // Fallback for rolling releases (debian:unstable/testing, arch, etc.)
-      // that don't have VERSION_ID but have VERSION_CODENAME
+      // that don't have VERSION_ID but have VERSION_CODENAME or BUILD_ID
       const versionCodename = parseOsReleaseValue(content, "VERSION_CODENAME");
+      const buildId = parseOsReleaseValue(content, "BUILD_ID");
 
       if (id && versionId) {
         return `${id}-${versionId}`;
       }
       if (id && versionCodename) {
         return `${id}-${versionCodename}`;
+      }
+      if (id && buildId) {
+        return `${id}-${buildId}`;
       }
     } catch {
       // Try next file


### PR DESCRIPTION
On Arch Linux based runners, the setup fails with because `/etc/os-release` does not contain `VERSION_ID` or `VERSION_CODENAME`. It does contain a `BUILD_ID` which is set to `rolling`:

```sh
$ cat /etc/os-release
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo
```

This PR makes `getLinuxOSNameVersion` return `arch-rolling`.

There is no update from arch that would change the returned value, so the same cache will always be used. Is this an issue? I'm not sure. At least it's better than crashing because `os-release` does not contain the expected values :).