### PR TITLE
Strip environment markers from detected uv dependency pins

### DIFF
--- a/__tests__/version/requirements-file.test.ts
+++ b/__tests__/version/requirements-file.test.ts
@@ -1,9 +1,34 @@
 import { expect, test } from "@jest/globals";
 import { getUvVersionFromFile } from "../../src/version/file-parser";
+import {
+  getUvVersionFromPyprojectContent,
+  getUvVersionFromRequirementsText,
+} from "../../src/version/requirements-file";
 
 test("ignores dependencies starting with uv", async () => {
   const parsedVersion = getUvVersionFromFile(
     "__tests__/fixtures/uv-in-requirements-txt-project/requirements.txt",
   );
   expect(parsedVersion).toBe("0.6.17");
+});
+
+test.each([
+  ["without space before marker", "uv==0.11.20; sys_platform != 'emscripten'"],
+  ["with space before marker", "uv==0.11.20 ; sys_platform != 'emscripten'"],
+])("strips PEP 508 markers from pyproject dependency groups %s", (_, dependency) => {
+  const parsedVersion = getUvVersionFromPyprojectContent(`[dependency-groups]
+test = [
+  "${dependency}",
+]
+`);
+
+  expect(parsedVersion).toBe("==0.11.20");
+});
+
+test("strips PEP 508 markers from requirements dependencies", () => {
+  const parsedVersion = getUvVersionFromRequirementsText(
+    "uv==0.11.20; sys_platform != 'emscripten'",
+  );
+
+  expect(parsedVersion).toBe("==0.11.20");
 });

--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -97414,7 +97414,11 @@ function parsePyprojectContent(pyprojectContent) {
   return parse4(pyprojectContent);
 }
 function getUvVersionFromAllDependencies(allDependencies) {
-  return allDependencies.find((dep) => dep.match(/^uv[=<>~!]/))?.match(/^uv([=<>~!]+\S*)/)?.[1].trim();
+  return allDependencies.map(getUvVersionFromDependency).find((version3) => version3 !== void 0);
+}
+function getUvVersionFromDependency(dependency) {
+  const dependencyWithoutMarker = dependency.split(";", 1)[0]?.trim();
+  return dependencyWithoutMarker?.match(/^uv([=<>~!]+\S*)/)?.[1].trim();
 }
 
 // src/version/tool-versions-file.ts

--- a/src/version/requirements-file.ts
+++ b/src/version/requirements-file.ts
@@ -63,7 +63,11 @@ function getUvVersionFromAllDependencies(
   allDependencies: string[],
 ): string | undefined {
   return allDependencies
-    .find((dep: string) => dep.match(/^uv[=<>~!]/))
-    ?.match(/^uv([=<>~!]+\S*)/)?.[1]
-    .trim();
+    .map(getUvVersionFromDependency)
+    .find((version): version is string => version !== undefined);
+}
+
+function getUvVersionFromDependency(dependency: string): string | undefined {
+  const dependencyWithoutMarker = dependency.split(";", 1)[0]?.trim();
+  return dependencyWithoutMarker?.match(/^uv([=<>~!]+\S*)/)?.[1].trim();
 }


### PR DESCRIPTION
## Summary
- strip PEP 508 environment markers before extracting uv versions from dependency entries
- cover dependency-group pins with and without whitespace before the marker
- cover requirements-style pins with markers

Fixes #920

## Validation
- npm ci --ignore-scripts
- npm run all

Refs: pi-session 019f316a-4108-7975-892f-ee5bf8abc7c3