### PR TITLE
fix: fall back to distribution ID when os-release has no version field

### DIFF
--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -90522,6 +90522,9 @@ function getLinuxOSNameVersion() {
       if (id && buildId) {
         return `${id}-${buildId}`;
       }
+      if (id) {
+        return id;
+      }
     } catch {
     }
   }

--- a/dist/setup/index.cjs
+++ b/dist/setup/index.cjs
@@ -90506,6 +90506,7 @@ function getOSNameVersion() {
 }
 function getLinuxOSNameVersion() {
   const files = ["/etc/os-release", "/usr/lib/os-release"];
+  let idWithoutVersion;
   for (const file of files) {
     try {
       const content = import_node_fs2.default.readFileSync(file, "utf8");
@@ -90522,11 +90523,14 @@ function getLinuxOSNameVersion() {
       if (id && buildId) {
         return `${id}-${buildId}`;
       }
-      if (id) {
-        return id;
+      if (id && idWithoutVersion === void 0) {
+        idWithoutVersion = id;
       }
     } catch {
     }
+  }
+  if (idWithoutVersion) {
+    return idWithoutVersion;
   }
   throw new Error(
     "Failed to determine Linux distribution. Could not read /etc/os-release or /usr/lib/os-release"

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -102,6 +102,7 @@ export function getOSNameVersion(): string {
 
 function getLinuxOSNameVersion(): string {
   const files = ["/etc/os-release", "/usr/lib/os-release"];
+  let idWithoutVersion: string | undefined;
 
   for (const file of files) {
     try {
@@ -122,14 +123,20 @@ function getLinuxOSNameVersion(): string {
       if (id && buildId) {
         return `${id}-${buildId}`;
       }
-      // Fallback for rolling releases (e.g. void) that have no version
-      // field at all
-      if (id) {
-        return id;
+      // Remember the ID but keep looking: the next file might still
+      // provide a version field
+      if (id && idWithoutVersion === undefined) {
+        idWithoutVersion = id;
       }
     } catch {
       // Try next file
     }
+  }
+
+  // Fallback for rolling releases (e.g. void) that have no version
+  // field at all
+  if (idWithoutVersion) {
+    return idWithoutVersion;
   }
 
   throw new Error(

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -122,6 +122,11 @@ function getLinuxOSNameVersion(): string {
       if (id && buildId) {
         return `${id}-${buildId}`;
       }
+      // Fallback for rolling releases (e.g. void) that have no version
+      // field at all
+      if (id) {
+        return id;
+      }
     } catch {
       // Try next file
     }


### PR DESCRIPTION
## Summary

`getLinuxOSNameVersion()` throws `Failed to determine Linux distribution. Could not read /etc/os-release or /usr/lib/os-release` on distributions whose os-release is readable but contains **no version field at all** — no `VERSION_ID`, no `VERSION_CODENAME`, no `BUILD_ID`. The error message is misleading in that case, and the action fails even though the distribution is perfectly identifiable.

Void Linux is such a distribution. Its os-release is:

```sh
$ cat /etc/os-release
NAME="Void"
ID="void"
PRETTY_NAME="Void Linux"
HOME_URL="https://voidlinux.org/"
DOCUMENTATION_URL="https://docs.voidlinux.org/"
LOGO="void-logo"
ANSI_COLOR="0;38;2;71;128;97"

DISTRIB_ID="void"
```

Unlike Arch (fixed by #912 via `BUILD_ID`) and debian:unstable (fixed via `VERSION_CODENAME`, #773), Void ships only `ID`, so both existing fallbacks miss it. This breaks any workflow using `container: ghcr.io/void-linux/void-glibc-full` with caching enabled — e.g. SageMath's CI started failing after bumping to v8: https://github.com/sagemath/sage/actions/runs/29456228986/job/87489892141 (worked around downstream in https://github.com/sagemath/sage/pull/42547 by injecting a fake `BUILD_ID` into the container's os-release).

This PR adds a last-resort fallback: if `ID` is present but no version field is, return the plain `ID` (`void`), following the same reasoning as #912 — a stable cache key for a rolling release is better than crashing. Distributions with a version field are unaffected, and files without even an `ID` still raise the existing error.

## Test Plan

- `npm run all` passes (build, biome check, package, 83 unit tests).
- Verified the compiled function against real os-release contents (`fs.readFileSync` stubbed):
  - Void (above) → `void` (previously: throw)
  - Arch (`ID=arch`, `BUILD_ID=rolling`) → `arch-rolling` (unchanged)
  - Ubuntu (`ID=ubuntu`, `VERSION_ID="24.04"`) → `ubuntu-24.04` (unchanged)
  - os-release with no `ID` → still throws (unchanged)