### PR TITLE
ci: pin Alpine container image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -489,7 +489,7 @@ jobs:
 
   test-musl:
     runs-on: ubuntu-latest
-    container: alpine
+    container: alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b # 3.24.1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

- pin the Alpine test container to the current multi-platform digest for Alpine 3.24.1
- resolve zizmor's `unpinned-images` finding

## Validation

- `actionlint .github/workflows/test.yml`
- `uvx zizmor .github/workflows/test.yml`
- `docker buildx imagetools inspect alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b`

Refs: pi-session 019ff01a-544c-79f3-8f73-a00132af39f5