### PR TITLE
ci: remove obsolete direct push attempts

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -60,20 +60,8 @@ jobs:
           else
               echo "changes-exist=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Commit and push changes
-        if: ${{ steps.changes-exist.outputs.changes-exist == 'true' }}
-        id: commit-and-push
-        continue-on-error: true
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add .
-          git commit -m "docs: update version references to $NEW_VERSION"
-          git push origin HEAD:refs/heads/main
-        env:
-          NEW_VERSION: ${{ steps.tag-info.outputs.tag }}
       - name: Create Pull Request
-        if: ${{ steps.changes-exist.outputs.changes-exist == 'true' && steps.commit-and-push.outcome != 'success' }}
+        if: ${{ steps.changes-exist.outputs.changes-exist == 'true' }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "docs: update version references to ${{ steps.tag-info.outputs.tag }}"

--- a/.github/workflows/update-known-checksums.yml
+++ b/.github/workflows/update-known-checksums.yml
@@ -39,21 +39,8 @@ jobs:
       - name: Compile changes
         if: ${{ steps.changes-exist.outputs.changes-exist == 'true' }}
         run: npm ci --ignore-scripts && npm run all
-      - name: Commit and push changes
-        if: ${{ steps.changes-exist.outputs.changes-exist == 'true' }}
-        id: commit-and-push
-        continue-on-error: true
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add .
-          git commit -m "chore: update known checksums for $LATEST_VERSION"
-          git push origin HEAD:refs/heads/main
-        env:
-          LATEST_VERSION: ${{ steps.update-known-checksums.outputs.latest-version }}
-
       - name: Create Pull Request
-        if: ${{ steps.changes-exist.outputs.changes-exist == 'true' && steps.commit-and-push.outcome != 'success' }}
+        if: ${{ steps.changes-exist.outputs.changes-exist == 'true' }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore: update known checksums"


### PR DESCRIPTION
## Summary
- remove direct pushes to `main` from the docs update workflow
- remove the same dead push path from the known-checksums workflow
- create update pull requests directly when changes exist

Direct pushes cannot satisfy the repository rule requiring changes through pull requests.

## Validation
- `npm ci --ignore-scripts`
- `npm run all`
- `actionlint .github/workflows/update-docs.yml .github/workflows/update-known-checksums.yml`
- `uvx zizmor .github/workflows/update-docs.yml .github/workflows/update-known-checksums.yml`

Refs: pi-session 019fff9d-7357-783c-8529-65bc5bf562c2