### PR TITLE
Add dependency cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 30
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 30

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age = 7


### PR DESCRIPTION
This does two things:

- Bumps our Dependabot-side cooldowns to 30d
- Adds an NPM-side 7d cooldown

The idea is to give automated cooldowns a longer period, whereas humans doing maintenance/manual bumps can opt into a newer package as needed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>