### PR TITLE
Pin one-shot tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,7 +314,7 @@ jobs:
           persist-credentials: false
       - name: Install default version
         uses: ./
-      - run: uvx ruff --version
+      - run: uvx ruff@0.14.10 --version
 
   test-tool-install:
     runs-on: ${{ matrix.os }}
@@ -327,7 +327,7 @@ jobs:
           persist-credentials: false
       - name: Install default version
         uses: ./
-      - run: uv tool install ruff
+      - run: uv tool install ruff==0.14.10
       - run: ruff --version
 
   test-python-version:


### PR DESCRIPTION
This just adds some pins to the action tests; these tests don't rely on the packages under test being unpinned.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>